### PR TITLE
Fix `HTTP/2` pool `recordPendingSuccess/FailureAndLatency` not recorded without timeout

### DIFF
--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -760,9 +760,11 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 				long estimateStreamsCount = pool.totalMaxConcurrentStreams - pool.acquired;
 				int permits = pool.poolConfig.allocationStrategy().estimatePermitCount();
 				int pending = pool.pendingSize;
-				if (!acquireTimeout.isZero() && permits + estimateStreamsCount <= pending) {
+				if (permits + estimateStreamsCount <= pending) {
 					pendingAcquireStart = pool.clock.millis();
-					timeoutTask = pool.poolConfig.pendingAcquireTimer().apply(this, acquireTimeout);
+					if (!acquireTimeout.isZero()) {
+						timeoutTask = pool.poolConfig.pendingAcquireTimer().apply(this, acquireTimeout);
+					}
 				}
 				pool.doAcquire(this);
 			}
@@ -822,13 +824,15 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 		}
 
 		void stopPendingCountdown(boolean success) {
-			if (!timeoutTask.isDisposed()) {
+			if (pendingAcquireStart > 0) {
 				if (success) {
 					pool.poolConfig.metricsRecorder().recordPendingSuccessAndLatency(pool.clock.millis() - pendingAcquireStart);
 				}
 				else {
 					pool.poolConfig.metricsRecorder().recordPendingFailureAndLatency(pool.clock.millis() - pendingAcquireStart);
 				}
+
+				pendingAcquireStart = 0;
 			}
 			timeoutTask.dispose();
 		}


### PR DESCRIPTION
pr_rerun pending-acquire-timer to 1.1.x