### PR TITLE
Fix `HTTP/2` pool `recordPendingSuccess/FailureAndLatency` not recorded without timeout

### DIFF
--- a/.github/workflows/check_graalvm.yml
+++ b/.github/workflows/check_graalvm.yml
@@ -18,7 +18,7 @@ jobs:
             transport: native
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Set up JDK 1.8
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:

--- a/.github/workflows/check_netty_snapshots.yml
+++ b/.github/workflows/check_netty_snapshots.yml
@@ -22,7 +22,7 @@ jobs:
             transport: native
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Set up JDK 1.8
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:

--- a/.github/workflows/check_reactor_core_3.6_snapshots.yml
+++ b/.github/workflows/check_reactor_core_3.6_snapshots.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           ref: '1.1.x'
       - name: Set up JDK 1.8

--- a/.github/workflows/check_reactor_core_3.6_snapshots.yml
+++ b/.github/workflows/check_reactor_core_3.6_snapshots.yml
@@ -19,4 +19,4 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
       - name: Build with Gradle
-        run: ./gradlew clean check --no-daemon -PforceTransport=nio -PreactorCoreVersion='3.6.6-SNAPSHOT' -PforceContextPropagationVersion='1.1.0'
+        run: ./gradlew clean check --no-daemon -PforceTransport=nio -PreactorCoreVersion='3.6.7-SNAPSHOT' -PforceContextPropagationVersion='1.1.0'

--- a/.github/workflows/check_transport.yml
+++ b/.github/workflows/check_transport.yml
@@ -8,7 +8,7 @@ jobs:
     name: preliminary sanity checks
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0 #needed by spotless
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
@@ -50,7 +50,7 @@ jobs:
           - os: windows-2019
             transport: native
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - uses: gradle/actions/wrapper-validation@db19848a5fa7950289d3668fb053140cf3028d43
       - name: Set up JDK 1.8
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       versionType: ${{ steps.version.outputs.versionType }}
       fullVersion: ${{ steps.version.outputs.fullVersion }}
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: setup java
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
@@ -37,7 +37,7 @@ jobs:
     name: reactor-netty-http
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: setup java
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
@@ -51,7 +51,7 @@ jobs:
     name: reactor-netty-http-brave
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: setup java
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
@@ -65,7 +65,7 @@ jobs:
     name: reactor-netty-incubator-quic
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: setup java
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
@@ -83,7 +83,7 @@ jobs:
     if: needs.reactor-netty-core.outputs.versionType == 'SNAPSHOT'
     environment: snapshots
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
           distribution: 'temurin'
@@ -103,7 +103,7 @@ jobs:
     if: needs.reactor-netty-core.outputs.versionType == 'MILESTONE'
     environment: releases
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
           distribution: 'temurin'
@@ -125,7 +125,7 @@ jobs:
     if: needs.reactor-netty-core.outputs.versionType == 'RELEASE'
     environment: releases
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9
         with:
           distribution: 'temurin'
@@ -148,7 +148,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: tag
         run: |
           git config --local user.name 'reactorbot'
@@ -163,7 +163,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: tag
         run: |
           git config --local user.name 'reactorbot'

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ With `Gradle` from [repo.spring.io](https://repo.spring.io) or `Maven Central` r
     }
 
     dependencies {
-      //compile "io.projectreactor.netty:reactor-netty-core:1.1.19-SNAPSHOT"
-      compile "io.projectreactor.netty:reactor-netty-core:1.1.18"
-      //compile "io.projectreactor.netty:reactor-netty-http:1.1.19-SNAPSHOT"
-      compile "io.projectreactor.netty:reactor-netty-http:1.1.18"
+      //compile "io.projectreactor.netty:reactor-netty-core:1.1.20-SNAPSHOT"
+      compile "io.projectreactor.netty:reactor-netty-core:1.1.19"
+      //compile "io.projectreactor.netty:reactor-netty-http:1.1.20-SNAPSHOT"
+      compile "io.projectreactor.netty:reactor-netty-http:1.1.19"
     }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ ext {
 	assertJVersion = '3.25.3'
 	awaitilityVersion = '4.2.1'
 	hoverflyJavaVersion = '0.18.1'
-	tomcatVersion = '9.0.88'
+	tomcatVersion = '9.0.89'
 	boringSslVersion = '2.0.65.Final'
 	junitVersion = '5.10.2'
 	junitPlatformLauncherVersion = '1.10.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-reactorPoolVersion=1.0.5
-version=1.1.19
-reactorNettyQuicVersion=0.1.19
-reactorCoreVersion=3.5.17
-reactorAddonsVersion=3.5.1
-compatibleVersion=1.1.18
+reactorPoolVersion=1.0.6-SNAPSHOT
+version=1.1.20-SNAPSHOT
+reactorNettyQuicVersion=0.1.20-SNAPSHOT
+reactorCoreVersion=3.5.18-SNAPSHOT
+reactorAddonsVersion=3.5.2-SNAPSHOT
+compatibleVersion=1.1.19
 bomVersion=2022.0.19

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-reactorPoolVersion=1.0.6-SNAPSHOT
-version=1.1.19-SNAPSHOT
-reactorNettyQuicVersion=0.1.19-SNAPSHOT
-reactorCoreVersion=3.5.17-SNAPSHOT
-reactorAddonsVersion=3.5.2-SNAPSHOT
+reactorPoolVersion=1.0.5
+version=1.1.19
+reactorNettyQuicVersion=0.1.19
+reactorCoreVersion=3.5.17
+reactorAddonsVersion=3.5.1
 compatibleVersion=1.1.18
-bomVersion=2022.0.18
+bomVersion=2022.0.19

--- a/reactor-netty-core/src/contextPropagationTest/java/reactor/netty/ContextPropagationTest.java
+++ b/reactor-netty-core/src/contextPropagationTest/java/reactor/netty/ContextPropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ class ContextPropagationTest {
 					      .wiretap(true)
 					      .connect()
 					      .contextWrite(ctx -> ContextSnapshot.captureAll(registry).updateContext(ctx))
-					      .block();
+					      .block(Duration.ofSeconds(5));
 
 			assertThat(connection).isNotNull();
 

--- a/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/Metrics.java
@@ -293,6 +293,8 @@ public class Metrics {
 
 	public static final String UNKNOWN = "UNKNOWN";
 
+	public static final String NA = "na";
+
 	@Nullable
 	public static Observation currentObservation(ContextView contextView) {
 		if (contextView.hasKey(OBSERVATION_KEY)) {

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsHandler.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 
 import static reactor.netty.Metrics.CONNECT_TIME;
 import static reactor.netty.Metrics.ERROR;
+import static reactor.netty.Metrics.NA;
 import static reactor.netty.Metrics.OBSERVATION_REGISTRY;
 import static reactor.netty.Metrics.SUCCESS;
 import static reactor.netty.Metrics.TLS_HANDSHAKE_TIME;
@@ -110,12 +111,7 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public Timer getTimer() {
-			if (proxyAddress == null) {
-				return recorder.getConnectTimer(getName(), netPeerName + ":" + netPeerPort, status);
-			}
-			else {
-				return recorder.getConnectTimer(getName(), netPeerName + ":" + netPeerPort, proxyAddress, status);
-			}
+			return recorder.getConnectTimer(getName(), netPeerName + ":" + netPeerPort, proxyAddress == null ? NA : proxyAddress, status);
 		}
 
 		@Override
@@ -205,13 +201,8 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			if (proxyAddress == null) {
-				return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort, STATUS.asString(), status);
-			}
-			else {
-				return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort,
-						PROXY_ADDRESS.asString(), proxyAddress, STATUS.asString(), status);
-			}
+			return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort,
+					PROXY_ADDRESS.asString(), proxyAddress == null ? NA : proxyAddress, STATUS.asString(), status);
 		}
 
 		@Override
@@ -349,12 +340,12 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			if (proxyAddress == null) {
+			if (recorder.onServer) {
 				return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ':' + netPeerPort, STATUS.asString(), status);
 			}
 			else {
 				return KeyValues.of(REMOTE_ADDRESS.asString(), netPeerName + ':' + netPeerPort,
-						PROXY_ADDRESS.asString(), proxyAddress, STATUS.asString(), status);
+						PROXY_ADDRESS.asString(), proxyAddress == null ? NA : proxyAddress, STATUS.asString(), status);
 			}
 		}
 
@@ -375,12 +366,7 @@ public final class MicrometerChannelMetricsHandler extends AbstractChannelMetric
 
 		@Override
 		public Timer getTimer() {
-			if (proxyAddress == null) {
-				return recorder.getTlsHandshakeTimer(getName(), netPeerName + ':' + netPeerPort, status);
-			}
-			else {
-				return recorder.getTlsHandshakeTimer(getName(), netPeerName + ':' + netPeerPort, proxyAddress, status);
-			}
+			return recorder.getTlsHandshakeTimer(getName(), netPeerName + ':' + netPeerPort, proxyAddress == null ? NA : proxyAddress, status);
 		}
 	}
 }

--- a/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/channel/MicrometerChannelMetricsRecorder.java
@@ -36,6 +36,7 @@ import static reactor.netty.Metrics.CONNECT_TIME;
 import static reactor.netty.Metrics.DATA_RECEIVED;
 import static reactor.netty.Metrics.DATA_SENT;
 import static reactor.netty.Metrics.ERRORS;
+import static reactor.netty.Metrics.NA;
 import static reactor.netty.Metrics.PROXY_ADDRESS;
 import static reactor.netty.Metrics.REGISTRY;
 import static reactor.netty.Metrics.REMOTE_ADDRESS;
@@ -50,13 +51,10 @@ import static reactor.netty.Metrics.formatSocketAddress;
  * @since 0.9
  */
 public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder {
-	final ConcurrentMap<String, DistributionSummary> dataReceivedCacheNoProxy = new ConcurrentHashMap<>();
 	final ConcurrentMap<MeterKey, DistributionSummary> dataReceivedCache = new ConcurrentHashMap<>();
 
-	final ConcurrentMap<String, DistributionSummary> dataSentCacheNoProxy = new ConcurrentHashMap<>();
 	final ConcurrentMap<MeterKey, DistributionSummary> dataSentCache = new ConcurrentHashMap<>();
 
-	final ConcurrentMap<String, Counter> errorsCacheNoProxy = new ConcurrentHashMap<>();
 	final ConcurrentMap<MeterKey, Counter> errorsCache = new ConcurrentHashMap<>();
 
 	final ConcurrentMap<MeterKey, Timer> connectTimeCache = new ConcurrentHashMap<>();
@@ -69,38 +67,42 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 
 	final String name;
 	final String protocol;
+	final boolean onServer;
 
 	public MicrometerChannelMetricsRecorder(String name, String protocol) {
+		this(name, protocol, true);
+	}
+
+	public MicrometerChannelMetricsRecorder(String name, String protocol, boolean onServer) {
 		this.name = name;
 		this.protocol = protocol;
+		this.onServer = onServer;
 	}
 
 	@Override
 	public void recordDataReceived(SocketAddress remoteAddress, long bytes) {
-		String address = formatSocketAddress(remoteAddress);
-		DistributionSummary ds = MapUtils.computeIfAbsent(dataReceivedCacheNoProxy, address,
-				key -> filter(DistributionSummary.builder(name + DATA_RECEIVED)
-				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
-				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address)
-				                                 .register(REGISTRY)));
-		if (ds != null) {
-			ds.record(bytes);
-		}
+		recordDataReceived(remoteAddress, NA, bytes);
 	}
 
 	@Override
 	public void recordDataReceived(SocketAddress remoteAddress, SocketAddress proxyAddress, long bytes) {
+		recordDataReceived(remoteAddress, formatSocketAddress(proxyAddress), bytes);
+	}
+
+	void recordDataReceived(SocketAddress remoteAddress, @Nullable String proxyAddress, long bytes) {
 		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(null, address, proxyAddr, null, null);
-		DistributionSummary ds = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
-				key -> filter(DistributionSummary.builder(name + DATA_RECEIVED)
-				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
-				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
-				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddr)
-				                                 .register(REGISTRY)));
+		MeterKey meterKey = new MeterKey(null, address, proxyAddress, null, null);
+		DistributionSummary ds = MapUtils.computeIfAbsent(dataReceivedCache, meterKey, key -> {
+			DistributionSummary.Builder builder =
+					DistributionSummary.builder(name + DATA_RECEIVED)
+					                   .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
+					                   .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
+					                         ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address);
+			if (!onServer) {
+				builder.tag(ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress);
+			}
+			return filter(builder.register(REGISTRY));
+		});
 		if (ds != null) {
 			ds.record(bytes);
 		}
@@ -108,30 +110,28 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 
 	@Override
 	public void recordDataSent(SocketAddress remoteAddress, long bytes) {
-		String address = formatSocketAddress(remoteAddress);
-		DistributionSummary ds = MapUtils.computeIfAbsent(dataSentCacheNoProxy, address,
-				key -> filter(DistributionSummary.builder(name + DATA_SENT)
-				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
-				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address)
-				                                 .register(REGISTRY)));
-		if (ds != null) {
-			ds.record(bytes);
-		}
+		recordDataSent(remoteAddress, NA, bytes);
 	}
 
 	@Override
 	public void recordDataSent(SocketAddress remoteAddress, SocketAddress proxyAddress, long bytes) {
+		recordDataSent(remoteAddress, formatSocketAddress(proxyAddress), bytes);
+	}
+
+	void recordDataSent(SocketAddress remoteAddress, @Nullable String proxyAddress, long bytes) {
 		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(null, address, proxyAddr, null, null);
-		DistributionSummary ds = MapUtils.computeIfAbsent(dataSentCache, meterKey,
-				key -> filter(DistributionSummary.builder(name + DATA_SENT)
-				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
-				                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
-				                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
-				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddr)
-				                                 .register(REGISTRY)));
+		MeterKey meterKey = new MeterKey(null, address, proxyAddress, null, null);
+		DistributionSummary ds = MapUtils.computeIfAbsent(dataSentCache, meterKey, key -> {
+			DistributionSummary.Builder builder =
+					DistributionSummary.builder(name + DATA_SENT)
+					                   .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
+					                   .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
+					                         ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address);
+			if (!onServer) {
+				builder.tag(ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress);
+			}
+			return filter(builder.register(REGISTRY));
+		});
 		if (ds != null) {
 			ds.record(bytes);
 		}
@@ -139,28 +139,26 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 
 	@Override
 	public void incrementErrorsCount(SocketAddress remoteAddress) {
-		String address = formatSocketAddress(remoteAddress);
-		Counter c = MapUtils.computeIfAbsent(errorsCacheNoProxy, address,
-				key -> filter(Counter.builder(name + ERRORS)
-				                     .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
-				                           ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address)
-				                     .register(REGISTRY)));
-		if (c != null) {
-			c.increment();
-		}
+		incrementErrorsCount(remoteAddress, NA);
 	}
 
 	@Override
 	public void incrementErrorsCount(SocketAddress remoteAddress, SocketAddress proxyAddress) {
+		incrementErrorsCount(remoteAddress, formatSocketAddress(proxyAddress));
+	}
+
+	void incrementErrorsCount(SocketAddress remoteAddress, @Nullable String proxyAddress) {
 		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(null, address, proxyAddr, null, null);
-		Counter c = MapUtils.computeIfAbsent(errorsCache, meterKey,
-				key -> filter(Counter.builder(name + ERRORS)
-				                     .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
-				                           ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
-				                           ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddr)
-				                     .register(REGISTRY)));
+		MeterKey meterKey = new MeterKey(null, address, proxyAddress, null, null);
+		Counter c = MapUtils.computeIfAbsent(errorsCache, meterKey, key -> {
+			Counter.Builder builder = Counter.builder(name + ERRORS)
+			                                 .tags(ChannelMeters.ChannelMetersTags.URI.asString(), protocol,
+			                                       ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address);
+			if (!onServer) {
+				builder.tag(ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress);
+			}
+			return filter(builder.register(REGISTRY));
+		});
 		if (c != null) {
 			c.increment();
 		}
@@ -168,14 +166,24 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 
 	@Override
 	public void recordTlsHandshakeTime(SocketAddress remoteAddress, Duration time, String status) {
-		String address = formatSocketAddress(remoteAddress);
-		Timer timer = getTlsHandshakeTimer(name + TLS_HANDSHAKE_TIME, address, status);
+		Timer timer = getTlsHandshakeTimer(name + TLS_HANDSHAKE_TIME, formatSocketAddress(remoteAddress), NA, status);
 		if (timer != null) {
 			timer.record(time);
 		}
 	}
 
+	/**
+	 * Returns TLS handshake timer.
+	 *
+	 * @param name the timer name
+	 * @param address the remote address
+	 * @param status the status of the TLS handshake operation
+	 * @return TLS handshake timer
+	 * @deprecated as of 1.1.19. Prefer the {@link #getTlsHandshakeTimer(String, String, String, String)}.
+	 * This method will be removed in version 1.3.0.
+	 */
 	@Nullable
+	@Deprecated
 	public final Timer getTlsHandshakeTimer(String name, @Nullable String address, String status) {
 		MeterKey meterKey = new MeterKey(null, address, null, null, status);
 		return MapUtils.computeIfAbsent(tlsHandshakeTimeCache, meterKey,
@@ -186,57 +194,55 @@ public class MicrometerChannelMetricsRecorder implements ChannelMetricsRecorder 
 
 	@Override
 	public void recordTlsHandshakeTime(SocketAddress remoteAddress, SocketAddress proxyAddress, Duration time, String status) {
-		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		Timer timer = getTlsHandshakeTimer(name + TLS_HANDSHAKE_TIME, address, proxyAddr, status);
+		Timer timer = getTlsHandshakeTimer(name + TLS_HANDSHAKE_TIME, formatSocketAddress(remoteAddress), formatSocketAddress(proxyAddress), status);
 		if (timer != null) {
 			timer.record(time);
 		}
 	}
 
+	/**
+	 * Returns TLS handshake timer.
+	 *
+	 * @param name the timer name
+	 * @param remoteAddress the remote address
+	 * @param proxyAddress the proxy address
+	 * @param status the status of the TLS handshake operation
+	 * @return TLS handshake timer
+	 */
 	@Nullable
-	public final Timer getTlsHandshakeTimer(String name, @Nullable String address, @Nullable String proxyAddr, String status) {
-		MeterKey meterKey = new MeterKey(null, address, proxyAddr, null, status);
-		return MapUtils.computeIfAbsent(tlsHandshakeTimeCache, meterKey,
-				key -> filter(Timer.builder(name)
-				                   .tags(REMOTE_ADDRESS, address, PROXY_ADDRESS, proxyAddr, STATUS, status)
-				                   .register(REGISTRY)));
+	public final Timer getTlsHandshakeTimer(String name, @Nullable String remoteAddress, @Nullable String proxyAddress, String status) {
+		MeterKey meterKey = new MeterKey(null, remoteAddress, proxyAddress, null, status);
+		return MapUtils.computeIfAbsent(tlsHandshakeTimeCache, meterKey, key -> {
+			Timer.Builder builder = Timer.builder(name).tags(REMOTE_ADDRESS, remoteAddress, STATUS, status);
+			if (!onServer) {
+				builder.tag(PROXY_ADDRESS, proxyAddress);
+			}
+			return filter(builder.register(REGISTRY));
+		});
 	}
 
 	@Override
 	public void recordConnectTime(SocketAddress remoteAddress, Duration time, String status) {
-		String address = formatSocketAddress(remoteAddress);
-		Timer timer = getConnectTimer(name + CONNECT_TIME, address, status);
+		Timer timer = getConnectTimer(name + CONNECT_TIME, formatSocketAddress(remoteAddress), NA, status);
 		if (timer != null) {
 			timer.record(time);
 		}
-	}
-
-	@Nullable
-	final Timer getConnectTimer(String name, @Nullable String address, String status) {
-		MeterKey meterKey = new MeterKey(null, address, null, null, status);
-		return MapUtils.computeIfAbsent(connectTimeCache, meterKey,
-				key -> filter(Timer.builder(name)
-				                   .tags(REMOTE_ADDRESS, address, STATUS, status)
-				                   .register(REGISTRY)));
 	}
 
 	@Override
 	public void recordConnectTime(SocketAddress remoteAddress, SocketAddress proxyAddress, Duration time, String status) {
-		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		Timer timer = getConnectTimer(name + CONNECT_TIME, address, proxyAddr, status);
+		Timer timer = getConnectTimer(name + CONNECT_TIME, formatSocketAddress(remoteAddress), formatSocketAddress(proxyAddress), status);
 		if (timer != null) {
 			timer.record(time);
 		}
 	}
 
 	@Nullable
-	final Timer getConnectTimer(String name, @Nullable String address, @Nullable String proxyAddr, String status) {
-		MeterKey meterKey = new MeterKey(null, address, proxyAddr, null, status);
+	final Timer getConnectTimer(String name, @Nullable String remoteAddress, @Nullable String proxyAddress, String status) {
+		MeterKey meterKey = new MeterKey(null, remoteAddress, proxyAddress, null, status);
 		return MapUtils.computeIfAbsent(connectTimeCache, meterKey,
 				key -> filter(Timer.builder(name)
-				                   .tags(REMOTE_ADDRESS, address, PROXY_ADDRESS, proxyAddr, STATUS, status)
+				                   .tags(REMOTE_ADDRESS, remoteAddress, PROXY_ADDRESS, proxyAddress, STATUS, status)
 				                   .register(REGISTRY)));
 	}
 

--- a/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/resources/PooledConnectionProvider.java
@@ -201,36 +201,14 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 			                        if (pool instanceof GracefulShutdownInstrumentedPool) {
 			                            return ((GracefulShutdownInstrumentedPool<T>) pool)
 			                                    .disposeGracefully(disposeTimeout)
+			                                    .then(deRegisterDefaultMetrics(id, pool.config().metricsRecorder(), poolFactory.registrar, remoteAddress))
 			                                    .onErrorResume(t -> {
 			                                        log.error("Connection pool for [{}] didn't shut down gracefully", e.getKey(), t);
-			                                        return Mono.fromRunnable(() -> {
-			                                            if (poolFactory.registrar != null) {
-			                                                poolFactory.registrar.get().deRegisterMetrics(name, id, remoteAddress);
-			                                            }
-			                                            else if (Metrics.isMicrometerAvailable()) {
-			                                                deRegisterDefaultMetrics(id, remoteAddress);
-			                                                PoolMetricsRecorder recorder = pool.config().metricsRecorder();
-			                                                if (recorder instanceof Disposable) {
-			                                                    ((Disposable) recorder).dispose();
-			                                                }
-			                                            }
-			                                        });
+			                                        return deRegisterDefaultMetrics(id, pool.config().metricsRecorder(), poolFactory.registrar, remoteAddress);
 			                                    });
 			                        }
-			                        return pool.disposeLater().then(
-			                                Mono.<Void>fromRunnable(() -> {
-			                                    if (poolFactory.registrar != null) {
-			                                        poolFactory.registrar.get().deRegisterMetrics(name, id, remoteAddress);
-			                                    }
-			                                    else if (Metrics.isMicrometerAvailable()) {
-			                                        deRegisterDefaultMetrics(id, remoteAddress);
-			                                        PoolMetricsRecorder recorder = pool.config().metricsRecorder();
-			                                        if (recorder instanceof Disposable) {
-			                                            ((Disposable) recorder).dispose();
-			                                        }
-			                                    }
-			                                })
-			                        );
+			                        return pool.disposeLater()
+			                                   .then(deRegisterDefaultMetrics(id, pool.config().metricsRecorder(), poolFactory.registrar, remoteAddress));
 			                    })
 			                    .collect(Collectors.toList());
 			if (pools.isEmpty()) {
@@ -350,6 +328,20 @@ public abstract class PooledConnectionProvider<T extends Connection> implements 
 
 	protected void deRegisterDefaultMetrics(String id, SocketAddress remoteAddress) {
 		MicrometerPooledConnectionProviderMeterRegistrar.INSTANCE.deRegisterMetrics(name, id, remoteAddress);
+	}
+
+	Mono<Void> deRegisterDefaultMetrics(String id, PoolMetricsRecorder recorder, @Nullable Supplier<? extends MeterRegistrar> registrar, SocketAddress remoteAddress) {
+		return Mono.fromRunnable(() -> {
+			if (registrar != null) {
+				registrar.get().deRegisterMetrics(name, id, remoteAddress);
+			}
+			else if (Metrics.isMicrometerAvailable()) {
+				deRegisterDefaultMetrics(id, remoteAddress);
+				if (recorder instanceof Disposable) {
+					((Disposable) recorder).dispose();
+				}
+			}
+		});
 	}
 
 	final boolean compareAddresses(SocketAddress origin, SocketAddress target) {

--- a/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
+++ b/reactor-netty-core/src/main/java/reactor/netty/tcp/TcpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ public final class TcpClientConfig extends ClientTransportConfig<TcpClientConfig
 		static final MicrometerTcpClientMetricsRecorder INSTANCE = new MicrometerTcpClientMetricsRecorder();
 
 		MicrometerTcpClientMetricsRecorder() {
-			super(reactor.netty.Metrics.TCP_CLIENT_PREFIX, "tcp");
+			super(reactor.netty.Metrics.TCP_CLIENT_PREFIX, "tcp", false);
 		}
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/NettyOutboundTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ class NettyOutboundTest {
 		ChannelFuture f = channel.writeOneOutbound(1);
 
 		outbound.sendFile(Paths.get(getClass().getResource("/largeFile.txt").toURI()))
-		        .then().block();
+		        .then().block(Duration.ofSeconds(5));
 
 		assertThat(channel.inboundMessages()).isEmpty();
 		assertThat(channel.outboundMessages()).hasSize(2);
@@ -313,7 +313,7 @@ class NettyOutboundTest {
 
 		ChannelFuture f = channel.writeOneOutbound(1);
 		outbound.sendFileChunked(path, 0, Files.size(path))
-		        .then().block();
+		        .then().block(Duration.ofSeconds(5));
 
 		assertThat(channel.inboundMessages()).isEmpty();
 		assertThat(messageWritten).containsExactly(Integer.class, ChunkedNioFile.class);

--- a/reactor-netty-core/src/test/java/reactor/netty/channel/MonoSendManyTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/channel/MonoSendManyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package reactor.netty.channel;
 
 import java.lang.ref.WeakReference;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
@@ -156,7 +157,7 @@ class MonoSendManyTest {
 		            .consumeSubscriptionWith(s -> _w.add(new WeakReference<>(s)))
 		            .then(channel::runPendingTasks)
 		            .thenCancel()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 
 		System.gc();
 		wait(_w.get(0));

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpClientTests.java
@@ -1419,7 +1419,7 @@ public class TcpClientTests {
 		finally {
 			disposableServer.disposeNow();
 			loop.disposeLater()
-			    .block();
+			    .block(Duration.ofSeconds(5));
 		}
 	}
 

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpMetricsTests.java
@@ -24,6 +24,8 @@ import static reactor.netty.Metrics.DATA_RECEIVED;
 import static reactor.netty.Metrics.DATA_SENT;
 import static reactor.netty.Metrics.ERRORS;
 import static reactor.netty.Metrics.LOCAL_ADDRESS;
+import static reactor.netty.Metrics.NA;
+import static reactor.netty.Metrics.PROXY_ADDRESS;
 import static reactor.netty.Metrics.REMOTE_ADDRESS;
 import static reactor.netty.Metrics.STATUS;
 import static reactor.netty.Metrics.TCP_CLIENT_PREFIX;
@@ -247,8 +249,8 @@ class TcpMetricsTests {
 				.hasTotalAmountGreaterThanOrEqualTo(5);
 		assertCounter(registry, SERVER_ERRORS, summaryTags).isNull();
 
-		timerTags = new String[] {REMOTE_ADDRESS, serverAddress, STATUS, "SUCCESS"};
-		summaryTags = new String[] {REMOTE_ADDRESS, serverAddress, URI, "tcp"};
+		timerTags = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, STATUS, "SUCCESS"};
+		summaryTags = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, "tcp"};
 		assertTimer(registry, CLIENT_CONNECT_TIME, timerTags)
 				.hasCountEqualTo(1)
 				.hasTotalTimeGreaterThanOrEqualTo(0);
@@ -265,9 +267,9 @@ class TcpMetricsTests {
 
 	private void checkExpectationsNegative(int port) {
 		String address = "127.0.0.1:" + port;
-		String[] timerTags1 = new String[] {REMOTE_ADDRESS, address, STATUS, "ERROR"};
-		String[] timerTags2 = new String[] {REMOTE_ADDRESS, address, STATUS, "SUCCESS"};
-		String[] summaryTags = new String[] {REMOTE_ADDRESS, address, URI, "tcp"};
+		String[] timerTags1 = new String[] {REMOTE_ADDRESS, address, PROXY_ADDRESS, NA, STATUS, "ERROR"};
+		String[] timerTags2 = new String[] {REMOTE_ADDRESS, address, PROXY_ADDRESS, NA, STATUS, "SUCCESS"};
+		String[] summaryTags = new String[] {REMOTE_ADDRESS, address, PROXY_ADDRESS, NA, URI, "tcp"};
 
 		assertTimer(registry, CLIENT_CONNECT_TIME, timerTags1)
 				.hasCountEqualTo(1)

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class TcpResourcesTest {
 			TcpResources.disposeLoopsAndConnectionsLater();
 			assertThat(newTcpResources.isDisposed()).isFalse();
 
-			TcpResources.disposeLoopsAndConnectionsLater().block();
+			TcpResources.disposeLoopsAndConnectionsLater().block(Duration.ofSeconds(5));
 			assertThat(newTcpResources.isDisposed()).as("disposeLoopsAndConnectionsLater completion").isTrue();
 
 			assertThat(TcpResources.tcpResources.get()).isNull();
@@ -140,7 +140,7 @@ class TcpResourcesTest {
 		                               	try {
 			                                out.sendString(Flux.just("Hello World!"))
 			                                   .then()
-			                                   .block();
+			                                   .block(Duration.ofSeconds(5));
 		                                }
 		                                catch (RuntimeException e) {
 			                                latch.countDown();
@@ -170,7 +170,7 @@ class TcpResourcesTest {
 
 		TcpResources current = TcpResources.tcpResources.get();
 		TcpResources.disposeLoopsAndConnectionsLater()
-		            .block();
+		            .block(Duration.ofSeconds(5));
 		assertThat(current.isDisposed()).isTrue();
 	}
 }

--- a/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpSecureMetricsTests.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/tcp/TcpSecureMetricsTests.java
@@ -31,6 +31,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.netty.Metrics.NA;
+import static reactor.netty.Metrics.PROXY_ADDRESS;
 import static reactor.netty.Metrics.REMOTE_ADDRESS;
 import static reactor.netty.Metrics.STATUS;
 import static reactor.netty.Metrics.URI;
@@ -127,8 +129,8 @@ class TcpSecureMetricsTests extends TcpMetricsTests {
 
 		InetSocketAddress sa = (InetSocketAddress) disposableServer.channel().localAddress();
 		String serverAddress = sa.getHostString() + ":" + sa.getPort();
-		timerTags = new String[] {REMOTE_ADDRESS, serverAddress, STATUS, "SUCCESS"};
-		summaryTags = new String[] {REMOTE_ADDRESS, serverAddress, URI, "tcp"};
+		timerTags = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, STATUS, "SUCCESS"};
+		summaryTags = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, "tcp"};
 
 		assertTimer(registry, CLIENT_CONNECT_TIME, timerTags)
 				.hasCountEqualTo(1)

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportResolverHooksTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/ClientTransportResolverHooksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import reactor.netty.tcp.TcpServer;
 import reactor.test.StepVerifier;
 
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -51,7 +52,7 @@ class ClientTransportResolverHooksTest {
 				.doAfterResolve((conn, socketAddress) -> doAfterResolve.set(conn.channel().attr(TRACE_ID_KEY).get()))
 				.doOnResolveError((conn, th) -> doOnResolveError.set(conn.channel().attr(TRACE_ID_KEY).get()))
 				.connect()
-				.block();
+				.block(Duration.ofSeconds(5));
 
 		assertThat(doOnResolve).hasValue(TRACE_ID_VALUE);
 		assertThat(doAfterResolve).hasValue(TRACE_ID_VALUE);
@@ -81,7 +82,8 @@ class ClientTransportResolverHooksTest {
 				})
 				.connect()
 				.as(StepVerifier::create)
-				.verifyError(UnknownHostException.class);
+				.expectError(UnknownHostException.class)
+				.verify(Duration.ofSeconds(5));
 
 			assertThat(doOnResolve).hasValue(TRACE_ID_VALUE);
 			assertThat(doAfterResolve).hasValue(0);

--- a/reactor-netty-core/src/test/java/reactor/netty/transport/TransportConnectorTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/transport/TransportConnectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import reactor.netty.tcp.TcpClient;
 import reactor.netty.tcp.TcpClientConfig;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -36,13 +37,13 @@ class TransportConnectorTest {
 				transportConfig,
 				new RecordingChannelInitializer(),
 				new InetSocketAddress("localhost", 0),
-				false).block();
+				false).block(Duration.ofSeconds(5));
 		final RecordingChannelInitializer channelInitializer = new RecordingChannelInitializer();
 		assertThatThrownBy(() -> TransportConnector.bind(
 				transportConfig,
 				channelInitializer,
 				new InetSocketAddress("localhost", ((InetSocketAddress) channel1.localAddress()).getPort()),
-				false).block());
+				false).block(Duration.ofSeconds(5)));
 		final Channel channel2 = channelInitializer.channel;
 		assertThat(channel1.isRegistered()).isTrue();
 		assertThat(channel2.isRegistered()).isFalse();

--- a/reactor-netty-core/src/test/java/reactor/netty/udp/UdpResourcesTest.java
+++ b/reactor-netty-core/src/test/java/reactor/netty/udp/UdpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package reactor.netty.udp;
 
 import org.junit.jupiter.api.Test;
 import reactor.netty.resources.LoopResources;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,7 +41,7 @@ class UdpResourcesTest {
 
 		UdpResources current = UdpResources.udpResources.get();
 		UdpResources.shutdownLater()
-		            .block();
+		            .block(Duration.ofSeconds(5));
 		assertThat(current.isDisposed()).isTrue();
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
@@ -151,13 +152,9 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 			if (markSentHeaderAndBody(b)) {
 				HttpMessage msg = prepareHttpMessage(b);
 
-				try {
-					afterMarkSentHeaders();
-				}
-				catch (RuntimeException e) {
-					b.release();
-					throw e;
-				}
+				// If afterMarkSentHeaders throws an exception there is no need to release the ByteBuf here.
+				// It will be released by PostHeadersNettyOutbound as there are on error/cancel hooks
+				afterMarkSentHeaders();
 
 				return channel().writeAndFlush(msg);
 			}
@@ -472,7 +469,7 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 
 	static final Pattern SCHEME_PATTERN = Pattern.compile("^(https?|wss?)://.*$");
 
-	protected static final class PostHeadersNettyOutbound implements NettyOutbound, Consumer<Throwable>, Runnable {
+	protected static final class PostHeadersNettyOutbound extends AtomicBoolean implements NettyOutbound, Consumer<Throwable>, Runnable {
 
 		final Mono<Void> source;
 		final HttpOperations<?, ?> parent;
@@ -492,14 +489,14 @@ public abstract class HttpOperations<INBOUND extends NettyInbound, OUTBOUND exte
 
 		@Override
 		public void run() {
-			if (msg != null && msg.refCnt() > 0) {
+			if (msg != null && msg.refCnt() > 0 && compareAndSet(false, true)) {
 				msg.release();
 			}
 		}
 
 		@Override
 		public void accept(Throwable throwable) {
-			if (msg != null && msg.refCnt() > 0) {
+			if (msg != null && msg.refCnt() > 0 && compareAndSet(false, true)) {
 				msg.release();
 			}
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/MicrometerHttpMetricsRecorder.java
@@ -55,7 +55,11 @@ public class MicrometerHttpMetricsRecorder extends MicrometerChannelMetricsRecor
 	private final ConcurrentMap<MeterKey, Counter> errorsCache = new ConcurrentHashMap<>();
 
 	protected MicrometerHttpMetricsRecorder(String name, String protocol) {
-		super(name, protocol);
+		this(name, protocol, true);
+	}
+
+	protected MicrometerHttpMetricsRecorder(String name, String protocol, boolean onServer) {
+		super(name, protocol, onServer);
 	}
 
 	@Override

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2Pool.java
@@ -760,9 +760,11 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 				long estimateStreamsCount = pool.totalMaxConcurrentStreams - pool.acquired;
 				int permits = pool.poolConfig.allocationStrategy().estimatePermitCount();
 				int pending = pool.pendingSize;
-				if (!acquireTimeout.isZero() && permits + estimateStreamsCount <= pending) {
+				if (permits + estimateStreamsCount <= pending) {
 					pendingAcquireStart = pool.clock.millis();
-					timeoutTask = pool.poolConfig.pendingAcquireTimer().apply(this, acquireTimeout);
+					if (!acquireTimeout.isZero()) {
+						timeoutTask = pool.poolConfig.pendingAcquireTimer().apply(this, acquireTimeout);
+					}
 				}
 				pool.doAcquire(this);
 			}
@@ -822,13 +824,15 @@ final class Http2Pool implements InstrumentedPool<Connection>, InstrumentedPool.
 		}
 
 		void stopPendingCountdown(boolean success) {
-			if (!timeoutTask.isDisposed()) {
+			if (pendingAcquireStart > 0) {
 				if (success) {
 					pool.poolConfig.metricsRecorder().recordPendingSuccessAndLatency(pool.clock.millis() - pendingAcquireStart);
 				}
 				else {
 					pool.poolConfig.metricsRecorder().recordPendingFailureAndLatency(pool.clock.millis() - pendingAcquireStart);
 				}
+
+				pendingAcquireStart = 0;
 			}
 			timeoutTask.dispose();
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsHandler.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static reactor.netty.Metrics.NA;
 import static reactor.netty.Metrics.OBSERVATION_REGISTRY;
 import static reactor.netty.Metrics.RESPONSE_TIME;
 import static reactor.netty.Metrics.UNKNOWN;
@@ -188,12 +189,7 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 		@Override
 		public Timer getTimer() {
-			if (proxyAddress == null) {
-				return recorder.getResponseTimeTimer(getName(), netPeerName + ":" + netPeerPort, path, method, status);
-			}
-			else {
-				return recorder.getResponseTimeTimer(getName(), netPeerName + ":" + netPeerPort, proxyAddress, path, method, status);
-			}
+			return recorder.getResponseTimeTimer(getName(), netPeerName + ":" + netPeerPort, proxyAddress == null ? NA : proxyAddress, path, method, status);
 		}
 
 		@Override
@@ -205,15 +201,9 @@ final class MicrometerHttpClientMetricsHandler extends AbstractHttpClientMetrics
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues() {
-			if (proxyAddress == null) {
-				return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort,
-						STATUS.asString(), status, URI.asString(), path);
-			}
-			else {
-				return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort,
-						PROXY_ADDRESS.asString(), proxyAddress,
-						STATUS.asString(), status, URI.asString(), path);
-			}
+			return KeyValues.of(METHOD.asString(), method, REMOTE_ADDRESS.asString(), netPeerName + ":" + netPeerPort,
+					PROXY_ADDRESS.asString(), proxyAddress == null ? NA : proxyAddress,
+					STATUS.asString(), status, URI.asString(), path);
 		}
 	}
 }

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/MicrometerHttpClientMetricsRecorder.java
@@ -37,6 +37,7 @@ import static reactor.netty.Metrics.DATA_SENT_TIME;
 import static reactor.netty.Metrics.ERRORS;
 import static reactor.netty.Metrics.HTTP_CLIENT_PREFIX;
 import static reactor.netty.Metrics.METHOD;
+import static reactor.netty.Metrics.NA;
 import static reactor.netty.Metrics.PROXY_ADDRESS;
 import static reactor.netty.Metrics.REGISTRY;
 import static reactor.netty.Metrics.REMOTE_ADDRESS;
@@ -62,34 +63,26 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	private final ConcurrentMap<MeterKey, Counter> errorsCache = new ConcurrentHashMap<>();
 
 	private MicrometerHttpClientMetricsRecorder() {
-		super(HTTP_CLIENT_PREFIX, "http");
+		super(HTTP_CLIENT_PREFIX, "http", false);
 	}
 
 	@Override
 	public void recordDataReceivedTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
-		String address = formatSocketAddress(remoteAddress);
-		MeterKey meterKey = new MeterKey(uri, address, null, method, status);
-		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
-				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
-				                   .tags(HttpClientMeters.DataReceivedTimeTags.REMOTE_ADDRESS.asString(), address,
-				                         HttpClientMeters.DataReceivedTimeTags.URI.asString(), uri,
-				                         HttpClientMeters.DataReceivedTimeTags.METHOD.asString(), method,
-				                         HttpClientMeters.DataReceivedTimeTags.STATUS.asString(), status)
-				                   .register(REGISTRY)));
-		if (dataReceivedTime != null) {
-			dataReceivedTime.record(time);
-		}
+		recordDataReceivedTime(remoteAddress, NA, uri, method, status, time);
 	}
 
 	@Override
 	public void recordDataReceivedTime(SocketAddress remoteAddress, SocketAddress proxyAddress, String uri, String method, String status, Duration time) {
+		recordDataReceivedTime(remoteAddress, formatSocketAddress(proxyAddress), uri, method, status, time);
+	}
+
+	void recordDataReceivedTime(SocketAddress remoteAddress, @Nullable String proxyAddress, String uri, String method, String status, Duration time) {
 		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddr, method, status);
+		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, method, status);
 		Timer dataReceivedTime = MapUtils.computeIfAbsent(dataReceivedTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_RECEIVED_TIME)
 				                   .tags(HttpClientMeters.DataReceivedTimeTags.REMOTE_ADDRESS.asString(), address,
-				                         HttpClientMeters.DataReceivedTimeTags.PROXY_ADDRESS.asString(), proxyAddr,
+				                         HttpClientMeters.DataReceivedTimeTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                         HttpClientMeters.DataReceivedTimeTags.URI.asString(), uri,
 				                         HttpClientMeters.DataReceivedTimeTags.METHOD.asString(), method,
 				                         HttpClientMeters.DataReceivedTimeTags.STATUS.asString(), status)
@@ -101,28 +94,21 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 
 	@Override
 	public void recordDataSentTime(SocketAddress remoteAddress, String uri, String method, Duration time) {
-		String address = formatSocketAddress(remoteAddress);
-		MeterKey meterKey = new MeterKey(uri, address, null, method, null);
-		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
-				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
-				                   .tags(HttpClientMeters.DataSentTimeTags.REMOTE_ADDRESS.asString(), address,
-				                         HttpClientMeters.DataSentTimeTags.URI.asString(), uri,
-				                         HttpClientMeters.DataSentTimeTags.METHOD.asString(), method)
-				                   .register(REGISTRY)));
-		if (dataSentTime != null) {
-			dataSentTime.record(time);
-		}
+		recordDataSentTime(remoteAddress, NA, uri, method, time);
 	}
 
 	@Override
 	public void recordDataSentTime(SocketAddress remoteAddress, SocketAddress proxyAddress, String uri, String method, Duration time) {
+		recordDataSentTime(remoteAddress, formatSocketAddress(proxyAddress), uri, method, time);
+	}
+
+	void recordDataSentTime(SocketAddress remoteAddress, @Nullable String proxyAddress, String uri, String method, Duration time) {
 		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddr, method, null);
+		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, method, null);
 		Timer dataSentTime = MapUtils.computeIfAbsent(dataSentTimeCache, meterKey,
 				key -> filter(Timer.builder(name() + DATA_SENT_TIME)
 				                   .tags(HttpClientMeters.DataSentTimeTags.REMOTE_ADDRESS.asString(), address,
-				                         HttpClientMeters.DataSentTimeTags.PROXY_ADDRESS.asString(), proxyAddr,
+				                         HttpClientMeters.DataSentTimeTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                         HttpClientMeters.DataSentTimeTags.URI.asString(), uri,
 				                         HttpClientMeters.DataSentTimeTags.METHOD.asString(), method)
 				                   .register(REGISTRY)));
@@ -133,51 +119,47 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 
 	@Override
 	public void recordResponseTime(SocketAddress remoteAddress, String uri, String method, String status, Duration time) {
-		String address = formatSocketAddress(remoteAddress);
-		Timer responseTime = getResponseTimeTimer(name() + RESPONSE_TIME, address, uri, method, status);
+		Timer responseTime = getResponseTimeTimer(name() + RESPONSE_TIME, formatSocketAddress(remoteAddress), NA, uri, method, status);
 		if (responseTime != null) {
 			responseTime.record(time);
 		}
-	}
-
-	@Nullable
-	final Timer getResponseTimeTimer(String name, @Nullable String address, String uri, String method, String status) {
-		MeterKey meterKey = new MeterKey(uri, address, null, method, status);
-		return MapUtils.computeIfAbsent(responseTimeCache, meterKey,
-				key -> filter(Timer.builder(name)
-				                   .tags(REMOTE_ADDRESS, address, URI, uri, METHOD, method, STATUS, status)
-				                   .register(REGISTRY)));
 	}
 
 	@Override
 	public void recordResponseTime(SocketAddress remoteAddress, SocketAddress proxyAddress, String uri, String method, String status, Duration time) {
-		String address = formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		Timer responseTime = getResponseTimeTimer(name() + RESPONSE_TIME, address, proxyAddr, uri, method, status);
+		Timer responseTime = getResponseTimeTimer(name() + RESPONSE_TIME, formatSocketAddress(remoteAddress), formatSocketAddress(proxyAddress), uri, method, status);
 		if (responseTime != null) {
 			responseTime.record(time);
 		}
 	}
 
 	@Nullable
-	final Timer getResponseTimeTimer(String name, @Nullable String address, @Nullable String proxyAddress, String uri, String method, String status) {
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, method, status);
+	Timer getResponseTimeTimer(String name, @Nullable String remoteAddress, @Nullable String proxyAddress, String uri, String method, String status) {
+		MeterKey meterKey = new MeterKey(uri, remoteAddress, proxyAddress, method, status);
 		return MapUtils.computeIfAbsent(responseTimeCache, meterKey,
 				key -> filter(Timer.builder(name)
-				                   .tags(REMOTE_ADDRESS, address, PROXY_ADDRESS, proxyAddress, URI, uri, METHOD, method, STATUS, status)
+				                   .tags(REMOTE_ADDRESS, remoteAddress, PROXY_ADDRESS, proxyAddress, URI, uri, METHOD, method, STATUS, status)
 				                   .register(REGISTRY)));
 	}
 
 	@Override
+	public void recordDataReceived(SocketAddress remoteAddress, String uri, long bytes) {
+		recordDataReceived(remoteAddress, NA, uri, bytes);
+	}
+
+	@Override
 	public void recordDataReceived(SocketAddress remoteAddress, SocketAddress proxyAddress, String uri, long bytes) {
+		recordDataReceived(remoteAddress, formatSocketAddress(proxyAddress), uri, bytes);
+	}
+
+	void recordDataReceived(SocketAddress remoteAddress, @Nullable String proxyAddress, String uri, long bytes) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddr, null, null);
+		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, null, null);
 		DistributionSummary dataReceived = MapUtils.computeIfAbsent(dataReceivedCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_RECEIVED)
 				                                 .baseUnit(ChannelMeters.DATA_RECEIVED.getBaseUnit())
 				                                 .tags(ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
-				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddr,
+				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                                       ChannelMeters.ChannelMetersTags.URI.asString(), uri)
 				                                 .register(REGISTRY)));
 		if (dataReceived != null) {
@@ -186,15 +168,23 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	}
 
 	@Override
+	public void recordDataSent(SocketAddress remoteAddress, String uri, long bytes) {
+		recordDataSent(remoteAddress, NA, uri, bytes);
+	}
+
+	@Override
 	public void recordDataSent(SocketAddress remoteAddress, SocketAddress proxyAddress, String uri, long bytes) {
+		recordDataSent(remoteAddress, formatSocketAddress(proxyAddress), uri, bytes);
+	}
+
+	void recordDataSent(SocketAddress remoteAddress, @Nullable String proxyAddress, String uri, long bytes) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddr, null, null);
+		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, null, null);
 		DistributionSummary dataSent = MapUtils.computeIfAbsent(dataSentCache, meterKey,
 				key -> filter(DistributionSummary.builder(name() + DATA_SENT)
 				                                 .baseUnit(ChannelMeters.DATA_SENT.getBaseUnit())
 				                                 .tags(ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
-				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddr,
+				                                       ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                                       ChannelMeters.ChannelMetersTags.URI.asString(), uri)
 				                                 .register(REGISTRY)));
 		if (dataSent != null) {
@@ -203,14 +193,22 @@ final class MicrometerHttpClientMetricsRecorder extends MicrometerHttpMetricsRec
 	}
 
 	@Override
+	public void incrementErrorsCount(SocketAddress remoteAddress, String uri) {
+		incrementErrorsCount(remoteAddress, NA, uri);
+	}
+
+	@Override
 	public void incrementErrorsCount(SocketAddress remoteAddress, SocketAddress proxyAddress, String uri) {
+		incrementErrorsCount(remoteAddress, formatSocketAddress(proxyAddress), uri);
+	}
+
+	void incrementErrorsCount(SocketAddress remoteAddress, @Nullable String proxyAddress, String uri) {
 		String address = Metrics.formatSocketAddress(remoteAddress);
-		String proxyAddr = formatSocketAddress(proxyAddress);
-		MeterKey meterKey = new MeterKey(uri, address, proxyAddr, null, null);
+		MeterKey meterKey = new MeterKey(uri, address, proxyAddress, null, null);
 		Counter errors = MapUtils.computeIfAbsent(errorsCache, meterKey,
 				key -> filter(Counter.builder(name() + ERRORS)
 				                     .tags(ChannelMeters.ChannelMetersTags.REMOTE_ADDRESS.asString(), address,
-				                           ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddr,
+				                           ChannelMeters.ChannelMetersTags.PROXY_ADDRESS.asString(), proxyAddress,
 				                           ChannelMeters.ChannelMetersTags.URI.asString(), uri)
 				                     .register(REGISTRY)));
 		if (errors != null) {

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/AbstractHttpServerMetricsHandler.java
@@ -175,16 +175,13 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 
 			if (msg instanceof LastHttpContent) {
 				promise.addListener(future -> {
-					ChannelOperations<?, ?> channelOps = ChannelOperations.get(ctx.channel());
-					if (channelOps instanceof HttpServerOperations) {
-						try {
-							recordWrite((HttpServerOperations) channelOps);
-						}
-						catch (RuntimeException e) {
-							// Allow request-response exchange to continue, unaffected by metrics problem
-							if (log.isWarnEnabled()) {
-								log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
-							}
+					try {
+						recordWrite(ctx.channel());
+					}
+					catch (RuntimeException e) {
+						// Allow request-response exchange to continue, unaffected by metrics problem
+						if (log.isWarnEnabled()) {
+							log.warn(format(ctx.channel(), "Exception caught while recording metrics."), e);
 						}
 					}
 
@@ -299,7 +296,7 @@ abstract class AbstractHttpServerMetricsHandler extends ChannelDuplexHandler {
 		recorder().recordDataReceived(remoteSocketAddress, path, dataReceived);
 	}
 
-	protected void recordWrite(HttpServerOperations ops) {
+	protected void recordWrite(Channel channel) {
 		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
 		recorder().recordDataSentTime(path, method, status, dataSentTimeDuration);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/ContextAwareHttpServerMetricsHandler.java
@@ -15,6 +15,7 @@
  */
 package reactor.netty.http.server;
 
+import io.netty.channel.Channel;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.ContextView;
 
@@ -72,7 +73,7 @@ final class ContextAwareHttpServerMetricsHandler extends AbstractHttpServerMetri
 	}
 
 	@Override
-	protected void recordWrite(HttpServerOperations ops) {
+	protected void recordWrite(Channel channel) {
 		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
 		recorder().recordDataSentTime(contextView, path, method, status, dataSentTimeDuration);
 

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/Http2StreamBridgeServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,6 +176,16 @@ final class Http2StreamBridgeServerHandler extends ChannelDuplexHandler implemen
 	@SuppressWarnings("FutureReturnValueIgnored")
 	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
 		if (msg instanceof ByteBuf) {
+			if (!pendingResponse) {
+				if (HttpServerOperations.log.isDebugEnabled()) {
+					HttpServerOperations.log.debug(
+							format(ctx.channel(), "Dropped HTTP content, since response has been sent already: {}"), msg);
+				}
+				((ByteBuf) msg).release();
+				promise.setSuccess();
+				return;
+			}
+
 			//"FutureReturnValueIgnored" this is deliberate
 			ctx.write(new DefaultHttpContent((ByteBuf) msg), promise);
 		}

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/HttpTrafficHandler.java
@@ -171,7 +171,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 			if (persistentConnection) {
 				pendingResponses += 1;
 				if (HttpServerOperations.log.isDebugEnabled()) {
-					HttpServerOperations.log.debug(format(ctx.channel(), "Increasing pending responses, now {}"),
+					HttpServerOperations.log.debug(format(ctx.channel(), "Increasing pending responses count: {}"),
 							pendingResponses);
 				}
 				persistentConnection = isKeepAlive(request);
@@ -187,7 +187,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 			if (pendingResponses > 1) {
 				if (HttpServerOperations.log.isDebugEnabled()) {
 					HttpServerOperations.log.debug(format(ctx.channel(), "Buffering pipelined HTTP request, " +
-									"pending response count: {}, queue: {}"),
+									"pending responses count: {}, queue: {}"),
 							pendingResponses,
 							pipelined != null ? pipelined.size() : 0);
 				}
@@ -267,7 +267,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 		else if (overflow) {
 			if (HttpServerOperations.log.isDebugEnabled()) {
 				HttpServerOperations.log.debug(format(ctx.channel(), "Buffering pipelined HTTP content, " +
-								"pending response count: {}, pending pipeline:{}"),
+								"pending responses count: {}, queue: {}"),
 						pendingResponses,
 						pipelined != null ? pipelined.size() : 0);
 			}
@@ -335,7 +335,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 			if (!shouldKeepAlive()) {
 				if (HttpServerOperations.log.isDebugEnabled()) {
 					HttpServerOperations.log.debug(format(ctx.channel(), "Detected non persistent http " +
-									"connection, preparing to close"),
+									"connection, preparing to close. Pending responses count: {}"),
 							pendingResponses);
 				}
 				ctx.write(msg, promise.unvoid())
@@ -355,7 +355,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 				nonInformationalResponse = false;
 				pendingResponses -= 1;
 				if (HttpServerOperations.log.isDebugEnabled()) {
-					HttpServerOperations.log.debug(format(ctx.channel(), "Decreasing pending responses, now {}"),
+					HttpServerOperations.log.debug(format(ctx.channel(), "Decreasing pending responses count: {}"),
 							pendingResponses);
 				}
 			}
@@ -363,7 +363,7 @@ final class HttpTrafficHandler extends ChannelDuplexHandler
 			if (pipelined != null && !pipelined.isEmpty()) {
 				if (HttpServerOperations.log.isDebugEnabled()) {
 					HttpServerOperations.log.debug(format(ctx.channel(), "Draining next pipelined " +
-									"request, pending response count: {}, queued: {}"),
+									"HTTP request, pending responses count: {}, queued: {}"),
 							pendingResponses, pipelined.size());
 				}
 				ctx.executor()

--- a/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java
@@ -19,6 +19,7 @@ import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.transport.RequestReplyReceiverContext;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import reactor.netty.observability.ReactorNettyHandlerContext;
@@ -85,7 +86,7 @@ final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetrics
 	}
 
 	@Override
-	protected void recordWrite(HttpServerOperations ops) {
+	protected void recordWrite(Channel channel) {
 		Duration dataSentTimeDuration = Duration.ofNanos(System.nanoTime() - dataSentTime);
 		recorder().recordDataSentTime(path, method, status, dataSentTimeDuration);
 
@@ -100,7 +101,7 @@ final class MicrometerHttpServerMetricsHandler extends AbstractHttpServerMetrics
 		// Move the implementation from the recorder here
 		responseTimeObservation.stop();
 
-		setChannelContext(ops.channel(), parentContextView);
+		setChannelContext(channel, parentContextView);
 
 		responseTimeHandlerContext = null;
 		responseTimeObservation = null;

--- a/reactor-netty-http/src/noMicrometerTest/java/reactor/netty/http/client/HttpClientNoMicrometerTest.java
+++ b/reactor-netty-http/src/noMicrometerTest/java/reactor/netty/http/client/HttpClientNoMicrometerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ class HttpClientNoMicrometerTest {
 				      .responseContent()
 				      .aggregate()
 				      .asString()
-				      .block()
+				      .block(Duration.ofSeconds(5))
 		).doesNotThrowAnyException();
 
 		//we still assert that the custom recorder did receive events, since it is not based on micrometer

--- a/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/channel/ChannelOperationsHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ class ChannelOperationsHandlerTest extends BaseHttpTest {
 
 		StepVerifier.create(response.log())
 		            .expectError(IOException.class)
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 
 		abortServer.close();
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,7 +200,7 @@ class Http2Tests extends BaseHttpTest {
 		ConnectionProvider provider = builder.build();
 		doTestMaxActiveStreams(HttpClient.create(provider), 1, 1, 1);
 		provider.disposeLater()
-		        .block();
+		        .block(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -213,7 +213,7 @@ class Http2Tests extends BaseHttpTest {
 		ConnectionProvider provider = ConnectionProvider.create("testMaxActiveStreams_2", 1);
 		doTestMaxActiveStreams(HttpClient.create(provider), 2, 2, 0);
 		provider.disposeLater()
-		        .block();
+		        .block(Duration.ofSeconds(5));
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/Http2Tests.java
@@ -695,7 +695,7 @@ class Http2Tests extends BaseHttpTest {
 		    .as(StepVerifier::create)
 		    .assertNext(t -> assertThat(t.getT1()).isNotNull().hasSize(2).allMatch("doTestMaxStreams"::equals))
 		    .expectComplete()
-		    .verify(Duration.ofSeconds(5));
+		    .verify(Duration.ofSeconds(10));
 	}
 
 	@ParameterizedTest
@@ -731,6 +731,6 @@ class Http2Tests extends BaseHttpTest {
 		      .as(StepVerifier::create)
 		      .expectNextMatches(buf -> expectation.equals(buf.toString(Charset.defaultCharset())))
 		      .expectComplete()
-		      .verify(Duration.ofSeconds(5));
+		      .verify(Duration.ofSeconds(10));
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpCompressionClientServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,30 +23,39 @@ import java.lang.annotation.Target;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.zip.GZIPInputStream;
 
 import com.aayushatharva.brotli4j.decoder.DecoderJNI;
 import com.aayushatharva.brotli4j.decoder.DirectDecompress;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.BaseHttpTest;
 import reactor.netty.DisposableServer;
 import reactor.netty.SocketUtils;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.server.HttpServer;
+import reactor.netty.http.server.HttpServerResponse;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.netty.NettyPipeline.HttpCodec;
 
 /**
  * This test class verifies HTTP compression.
@@ -542,13 +551,24 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 	}
 
 	@Test
-	void testIssue825_2() {
+	void testIssue825SendMono() {
+		doTestIssue825_2((b, out) -> out.send(Mono.just(b)));
+	}
+
+	@Test
+	void testIssue825SendObject() {
+		doTestIssue825_2((b, out) -> out.sendObject(b));
+	}
+
+	private void doTestIssue825_2(BiFunction<ByteBuf, HttpServerResponse, Publisher<Void>> serverFn) {
 		int port1 = SocketUtils.findAvailableTcpPort();
 		int port2 = SocketUtils.findAvailableTcpPort();
 
 		AtomicReference<Throwable> error = new AtomicReference<>();
+		AtomicReference<Throwable> bufferReleasedError = new AtomicReference<>();
 		DisposableServer server1 = null;
 		DisposableServer server2 = null;
+		Sinks.Empty<Void> bufferReleased = Sinks.empty();
 		try {
 			server1 =
 					createServer(port1)
@@ -557,11 +577,33 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 					          })
 					          .handle((in, out) ->
 					              createClient(port2)
+					                        .doOnChannelInit((obs, ch, addr) ->
+					                            ch.pipeline().addAfter(HttpCodec, "doTestIssue825_2", new ChannelInboundHandlerAdapter() {
+					                                @Override
+					                                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+					                                    LastHttpContent last = null;
+					                                    int expectedRefCount = 0;
+					                                    if (msg instanceof LastHttpContent) {
+					                                        last = (LastHttpContent) msg;
+					                                        expectedRefCount = last.content().refCnt() - 1;
+					                                    }
+					                                    ctx.fireChannelRead(msg);
+					                                    if (last != null) {
+					                                        if (last.content().refCnt() == expectedRefCount) {
+					                                            bufferReleased.tryEmitEmpty();
+					                                        }
+					                                        else {
+					                                            bufferReleased.tryEmitError(new RuntimeException("The buffer is not released!"));
+					                                        }
+					                                    }
+					                                }
+					                            }))
 					                        .get()
 					                        .uri("/")
 					                        .responseContent()
 					                        .retain()
-					                        .flatMap(b -> out.send(Mono.just(b)))
+					                        .doOnError(bufferReleasedError::set)
+					                        .flatMap(b -> serverFn.apply(b, out))
 					                        .doOnError(error::set))
 					          .bindNow();
 
@@ -579,8 +621,14 @@ class HttpCompressionClientServerTests extends BaseHttpTest {
 			            .expectError()
 			            .verify(Duration.ofSeconds(30));
 
+			bufferReleased.asMono()
+			              .as(StepVerifier::create)
+			              .expectComplete()
+			              .verify(Duration.ofSeconds(5));
+
 			assertThat(error.get()).isNotNull()
 			                       .isInstanceOf(RuntimeException.class);
+			assertThat(bufferReleasedError.get()).isNull();
 		}
 		finally {
 			if (server1 != null) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpErrorTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpErrorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ class HttpErrorTests extends BaseHttpTest {
 		                             .asString(StandardCharsets.UTF_8)
 		                             .collectList())
 		            .expectNextMatches(List::isEmpty)
-		            .verifyComplete();
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -106,6 +106,8 @@ import static reactor.netty.Metrics.HTTP_CLIENT_PREFIX;
 import static reactor.netty.Metrics.HTTP_SERVER_PREFIX;
 import static reactor.netty.Metrics.LOCAL_ADDRESS;
 import static reactor.netty.Metrics.METHOD;
+import static reactor.netty.Metrics.NA;
+import static reactor.netty.Metrics.PROXY_ADDRESS;
 import static reactor.netty.Metrics.REMOTE_ADDRESS;
 import static reactor.netty.Metrics.RESPONSE_TIME;
 import static reactor.netty.Metrics.STATUS;
@@ -741,7 +743,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			assertGauge(registry, SERVER_CONNECTIONS_TOTAL, URI, HTTP, LOCAL_ADDRESS, address).hasValueEqualTo(0);
 			assertGauge(registry, SERVER_CONNECTIONS_ACTIVE, URI, HTTP, LOCAL_ADDRESS, address).hasValueEqualTo(0);
 			// https://github.com/reactor/reactor-netty/issues/3060
-			assertCounter(registry, CLIENT_ERRORS, REMOTE_ADDRESS, address, URI, "/6").hasCountGreaterThanOrEqualTo(1);
+			assertCounter(registry, CLIENT_ERRORS, REMOTE_ADDRESS, address, PROXY_ADDRESS, NA, URI, "/6").hasCountGreaterThanOrEqualTo(1);
 		}
 		else {
 			// make sure the client stream is closed on the server side before checking server metrics
@@ -749,7 +751,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			assertGauge(registry, SERVER_CONNECTIONS_TOTAL, URI, HTTP, LOCAL_ADDRESS, address).hasValueEqualTo(1);
 			assertGauge(registry, SERVER_STREAMS_ACTIVE, URI, HTTP, LOCAL_ADDRESS, address).hasValueEqualTo(0);
 			// https://github.com/reactor/reactor-netty/issues/3060
-			assertCounter(registry, CLIENT_ERRORS, REMOTE_ADDRESS, address, URI, "/6").hasCountGreaterThanOrEqualTo(1);
+			assertCounter(registry, CLIENT_ERRORS, REMOTE_ADDRESS, address, PROXY_ADDRESS, NA, URI, "/6").hasCountGreaterThanOrEqualTo(1);
 			// in case of H2, the tearDown method will ensure client socket is closed on the server side
 		}
 	}
@@ -865,7 +867,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
 			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
 			// https://github.com/reactor/reactor-netty/issues/3060
-			assertCounter(registry, CLIENT_ERRORS, REMOTE_ADDRESS, address, URI, "/7").hasCountGreaterThanOrEqualTo(1);
+			assertCounter(registry, CLIENT_ERRORS, PROXY_ADDRESS, NA, REMOTE_ADDRESS, address, URI, "/7").hasCountGreaterThanOrEqualTo(1);
 		}
 		else {
 			assertThat(StreamCloseHandler.INSTANCE.awaitClientClosedOnServer()).as("awaitClientClosedOnServer timeout").isTrue();
@@ -874,7 +876,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 			assertThat(ServerRecorder.INSTANCE.onActiveConnectionsLocalAddr.get()).isEqualTo(address);
 			assertThat(ServerRecorder.INSTANCE.onInactiveConnectionsLocalAddr.get()).isEqualTo(address);
 			// https://github.com/reactor/reactor-netty/issues/3060
-			assertCounter(registry, CLIENT_ERRORS, REMOTE_ADDRESS, address, URI, "/7").hasCountGreaterThanOrEqualTo(1);
+			assertCounter(registry, CLIENT_ERRORS, REMOTE_ADDRESS, address, PROXY_ADDRESS, NA, URI, "/7").hasCountGreaterThanOrEqualTo(1);
 			// in case of H2, the tearDown method will ensure client socket is closed on the server side
 		}
 	}
@@ -924,7 +926,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		InetSocketAddress sa = (InetSocketAddress) disposableServer.channel().localAddress();
 		String serverAddress = sa.getHostString() + ":" + sa.getPort();
-		String[] summaryTags = new String[]{REMOTE_ADDRESS, serverAddress, URI, "unknown"};
+		String[] summaryTags = new String[]{REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, "unknown"};
 		assertCounter(registry, CLIENT_ERRORS, summaryTags).hasCountGreaterThanOrEqualTo(2);
 	}
 
@@ -1068,7 +1070,7 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).as("latch await").isTrue();
 
-		String[] summaryTags = new String[]{REMOTE_ADDRESS, "1.1.1.1:11111", STATUS, ERROR};
+		String[] summaryTags = new String[]{REMOTE_ADDRESS, "1.1.1.1:11111", PROXY_ADDRESS, NA, STATUS, ERROR};
 		assertTimer(registry, CLIENT_CONNECT_TIME, summaryTags).hasCountEqualTo(1);
 	}
 
@@ -1223,11 +1225,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.hasTotalAmountGreaterThanOrEqualTo(12);
 		assertCounter(registry, SERVER_ERRORS, summaryTags1).isNull();
 
-		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "POST", STATUS, "200"};
-		timerTags2 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "POST"};
-		String[] timerTags3 = new String[] {REMOTE_ADDRESS, serverAddress, STATUS, "SUCCESS"};
-		summaryTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri};
-		String[] summaryTags2 = new String[] {REMOTE_ADDRESS, serverAddress, URI, "http"};
+		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri, METHOD, "POST", STATUS, "200"};
+		timerTags2 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri, METHOD, "POST"};
+		String[] timerTags3 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, STATUS, "SUCCESS"};
+		summaryTags1 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri};
+		String[] summaryTags2 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, "http"};
 
 		assertTimer(registry, CLIENT_RESPONSE_TIME, timerTags1)
 				.hasCountEqualTo(1)
@@ -1283,11 +1285,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.hasTotalAmountGreaterThanOrEqualTo(0);
 		assertCounter(registry, SERVER_ERRORS, summaryTags1).isNull();
 
-		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "GET", STATUS, "404"};
-		timerTags2 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "GET"};
-		String[] timerTags3 = new String[] {REMOTE_ADDRESS, serverAddress, STATUS, "SUCCESS"};
-		summaryTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri};
-		String[] summaryTags2 = new String[] {REMOTE_ADDRESS, serverAddress, URI, "http"};
+		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri, METHOD, "GET", STATUS, "404"};
+		timerTags2 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri, METHOD, "GET"};
+		String[] timerTags3 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, STATUS, "SUCCESS"};
+		summaryTags1 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri};
+		String[] summaryTags2 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, "http"};
 
 		assertTimer(registry, CLIENT_RESPONSE_TIME, timerTags1)
 				.hasCountEqualTo(index)
@@ -1334,11 +1336,11 @@ class HttpMetricsHandlerTests extends BaseHttpTest {
 				.hasTotalAmountGreaterThanOrEqualTo(0);
 		assertCounter(registry, SERVER_ERRORS, summaryTags1).isNull();
 
-		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "GET", STATUS, "431"};
-		String[] timerTags2 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri, METHOD, "GET"};
-		String[] timerTags3 = new String[] {REMOTE_ADDRESS, serverAddress, STATUS, "SUCCESS"};
-		summaryTags1 = new String[] {REMOTE_ADDRESS, serverAddress, URI, uri};
-		String[] summaryTags2 = new String[] {REMOTE_ADDRESS, serverAddress, URI, "http"};
+		timerTags1 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri, METHOD, "GET", STATUS, "431"};
+		String[] timerTags2 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri, METHOD, "GET"};
+		String[] timerTags3 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, STATUS, "SUCCESS"};
+		summaryTags1 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, uri};
+		String[] summaryTags2 = new String[] {REMOTE_ADDRESS, serverAddress, PROXY_ADDRESS, NA, URI, "http"};
 
 		assertTimer(registry, CLIENT_RESPONSE_TIME, timerTags1)
 				.hasCountEqualTo(1)

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpProtocolsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -653,7 +653,8 @@ class HttpProtocolsTests extends BaseHttpTest {
 		                          .asString()
 		                          .timeout(Duration.ofSeconds(10)))
 		            .expectNext("Hello world!")
-		            .verifyComplete();
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
 
 		try {
 			// Wait till all logs are flushed

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpResourcesTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ class HttpResourcesTest {
 			HttpResources.disposeLoopsAndConnectionsLater();
 			assertThat(newHttpResources.isDisposed()).isFalse();
 
-			HttpResources.disposeLoopsAndConnectionsLater().block();
+			HttpResources.disposeLoopsAndConnectionsLater().block(Duration.ofSeconds(5));
 			assertThat(newHttpResources.isDisposed()).as("disposeLoopsAndConnectionsLater completion").isTrue();
 
 			assertThat(HttpResources.httpResources.get()).isNull();
@@ -123,7 +123,7 @@ class HttpResourcesTest {
 
 		HttpResources current = HttpResources.httpResources.get();
 		HttpResources.disposeLoopsAndConnectionsLater()
-		             .block();
+		             .block(Duration.ofSeconds(5));
 		assertThat(current.isDisposed()).isTrue();
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpResponseStatusCodesHandlingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,8 @@ class HttpResponseStatusCodesHandlingTests extends BaseHttpTest {
 
 		StepVerifier.create(content)
 				    .expectNext(404)
-				    .verifyComplete();
+				    .expectComplete()
+				    .verify(Duration.ofSeconds(5));
 	}
 
 	@ParameterizedTest

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,7 +169,8 @@ class HttpTests extends BaseHttpTest {
 
 		StepVerifier.create(code)
 				    .expectNext(500)
-				    .verifyComplete();
+				    .expectComplete()
+				    .verify(Duration.ofSeconds(5));
 
 		Mono<ByteBuf> content =
 				client.get()
@@ -233,7 +234,8 @@ class HttpTests extends BaseHttpTest {
 
 		StepVerifier.create(code)
 		            .expectNext(500)
-		            .verifyComplete();
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	/*
@@ -326,7 +328,7 @@ class HttpTests extends BaseHttpTest {
 				          .aggregate()
 				          .asString()
 				          .log()
-				          .block();
+				          .block(Duration.ofSeconds(5));
 
 		Flux<String> f = createClient(disposableServer.port())
 		                           .compress(true)
@@ -345,7 +347,8 @@ class HttpTests extends BaseHttpTest {
 		            .expectNext("test2")
 		            .thenAwait(Duration.ofMillis(30))
 		            .then(() -> ep.tryEmitComplete().orThrow())
-		            .verifyComplete();
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
 
 
 
@@ -358,7 +361,7 @@ class HttpTests extends BaseHttpTest {
 		          .aggregate()
 		          .asString()
 		          .log()
-		          .block();
+		          .block(Duration.ofSeconds(5));
 	}
 
 
@@ -391,7 +394,7 @@ class HttpTests extends BaseHttpTest {
 				          .aggregate()
 				          .asString()
 				          .log()
-				          .block();
+				          .block(Duration.ofSeconds(5));
 
 		Flux<String> f = createClient(disposableServer.port())
 		                           .compress(true)
@@ -410,7 +413,8 @@ class HttpTests extends BaseHttpTest {
 		            .expectNext("test2")
 		            .thenAwait(Duration.ofMillis(30))
 		            .then(() -> ep.tryEmitComplete().orThrow())
-		            .verifyComplete();
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
 
 
 
@@ -423,7 +427,7 @@ class HttpTests extends BaseHttpTest {
 		          .aggregate()
 		          .asString()
 		          .log()
-		          .block();
+		          .block(Duration.ofSeconds(5));
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/Http2PoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ class Http2PoolTest {
 
 		Connection connection = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -174,13 +174,13 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(0);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -192,7 +192,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
@@ -232,7 +232,7 @@ class Http2PoolTest {
 
 		Connection connection = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -252,7 +252,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(Integer.MAX_VALUE);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 			assertThat(acquired2).isNotNull();
 
 			AtomicReference<PooledRef<Connection>> acquired3 = new AtomicReference<>();
@@ -277,14 +277,14 @@ class Http2PoolTest {
 			ChannelId id2 = connection.channel().id();
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired1.invalidate().block();
-			acquired2.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(Integer.MAX_VALUE);
 
-			acquired3.get().invalidate().block();
+			acquired3.get().invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			if (closeSecond) {
@@ -320,7 +320,7 @@ class Http2PoolTest {
 
 		Connection connection = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -348,7 +348,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(0);
@@ -379,7 +379,7 @@ class Http2PoolTest {
 
 		Connection connection = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -399,7 +399,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			http2Pool.evictInBackground();
 
@@ -407,7 +407,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(0);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -419,7 +419,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			http2Pool.evictInBackground();
 
@@ -454,7 +454,7 @@ class Http2PoolTest {
 		Connection connection1 = null;
 		Connection connection2 = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -464,7 +464,7 @@ class Http2PoolTest {
 			connection1 = acquired1.poolable();
 			ChannelId id1 = connection1.channel().id();
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			Thread.sleep(15);
 
@@ -474,7 +474,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(0);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -486,7 +486,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			Thread.sleep(15);
 
@@ -527,7 +527,7 @@ class Http2PoolTest {
 		Connection connection1 = null;
 		Connection connection2 = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -543,7 +543,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			http2Pool.evictInBackground();
 
@@ -551,7 +551,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(0);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -563,7 +563,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			Thread.sleep(10);
 
@@ -605,7 +605,7 @@ class Http2PoolTest {
 		Connection connection1 = null;
 		Connection connection2 = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -621,7 +621,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			http2Pool.evictInBackground();
 
@@ -631,7 +631,7 @@ class Http2PoolTest {
 
 			shouldEvict.set(false);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -643,7 +643,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			shouldEvict.set(true);
 
@@ -683,7 +683,7 @@ class Http2PoolTest {
 		Connection connection1 = null;
 		Connection connection2 = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -693,11 +693,11 @@ class Http2PoolTest {
 			connection1 = acquired1.poolable();
 			ChannelId id1 = connection1.channel().id();
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			Thread.sleep(15);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -709,7 +709,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
@@ -756,7 +756,7 @@ class Http2PoolTest {
 			connection1 = acquired.get(0).poolable();
 			ChannelId id1 = connection1.channel().id();
 
-			acquired.get(0).invalidate().block();
+			acquired.get(0).invalidate().block(Duration.ofSeconds(1));
 
 			Thread.sleep(15);
 
@@ -769,7 +769,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isEqualTo(id2);
 
-			acquired.get(1).invalidate().block();
+			acquired.get(1).invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
@@ -805,7 +805,7 @@ class Http2PoolTest {
 		Connection connection1 = null;
 		Connection connection2 = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -821,13 +821,13 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(0);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -839,7 +839,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
@@ -876,7 +876,7 @@ class Http2PoolTest {
 		Connection connection1 = null;
 		Connection connection2 = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -892,7 +892,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(0);
@@ -900,7 +900,7 @@ class Http2PoolTest {
 
 			shouldEvict.set(false);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -912,7 +912,7 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired2.invalidate().block();
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
@@ -948,7 +948,7 @@ class Http2PoolTest {
 		Connection connection1 = null;
 		Connection connection2 = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -964,7 +964,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			PooledRef<Connection> acquired2 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired2 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired2).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(2);
@@ -976,8 +976,8 @@ class Http2PoolTest {
 
 			assertThat(id1).isNotEqualTo(id2);
 
-			acquired1.invalidate().block();
-			acquired2.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
+			acquired2.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
@@ -1034,7 +1034,7 @@ class Http2PoolTest {
 
 		Connection connection = null;
 		try {
-			PooledRef<Connection> acquired1 = http2Pool.acquire().block();
+			PooledRef<Connection> acquired1 = http2Pool.acquire().block(Duration.ofSeconds(1));
 
 			assertThat(acquired1).isNotNull();
 			assertThat(http2Pool.activeStreams()).isEqualTo(1);
@@ -1058,7 +1058,7 @@ class Http2PoolTest {
 			assertThat(http2Pool.connections.size()).isEqualTo(1);
 			assertThat(http2Pool.totalMaxConcurrentStreams).isEqualTo(0);
 
-			acquired1.invalidate().block();
+			acquired1.invalidate().block(Duration.ofSeconds(1));
 
 			assertThat(http2Pool.activeStreams()).isEqualTo(0);
 			assertThat(http2Pool.connections.size()).isEqualTo(0);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -3135,7 +3135,7 @@ class HttpClientTest extends BaseHttpTest {
 				      .responseContent()
 				      .aggregate()
 				      .asString()
-				      .block(Duration.ofSeconds(5));
+				      .block(Duration.ofSeconds(10));
 
 		assertThat(response).isEqualTo("testIssue1697");
 		assertThat(onRequest.get()).isFalse();

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -366,7 +366,7 @@ class HttpClientTest extends BaseHttpTest {
 		        .get()
 		        .uri("/")
 		        .response()
-		        .block();
+		        .block(Duration.ofSeconds(5));
 
 		latch.await();
 	}
@@ -380,7 +380,7 @@ class HttpClientTest extends BaseHttpTest {
 		                              .response((r, buf) -> Mono.just(r.status().code())))
 		            .expectNextMatches(status -> status >= 200 && status < 400)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 
 		StepVerifier.create(HttpClient.create()
 		                              .wiretap(true)
@@ -389,7 +389,7 @@ class HttpClientTest extends BaseHttpTest {
 		                              .response((r, buf) -> Mono.just(r.status().code())))
 		            .expectNextMatches(status -> status >= 200 && status < 400)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -416,7 +416,8 @@ class HttpClientTest extends BaseHttpTest {
 				        .uri("/")
 				        .responseContent()
 				        .timeout(signal.asFlux()))
-				    .verifyError(TimeoutException.class);
+				    .expectError(TimeoutException.class)
+				    .verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -528,7 +529,7 @@ class HttpClientTest extends BaseHttpTest {
 		        .get()
 		        .uri("/")
 		        .responseContent()
-		        .blockLast();
+		        .blockLast(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -586,7 +587,7 @@ class HttpClientTest extends BaseHttpTest {
 		                                .get()
 		                                .uri("/foo")
 		                                .responseSingle((res, buf) -> buf.asString(CharsetUtil.UTF_8))
-		                                .block();
+		                                .block(Duration.ofSeconds(5));
 
 		assertThat(responseString).isEqualTo("hello /foo");
 	}
@@ -696,7 +697,7 @@ class HttpClientTest extends BaseHttpTest {
 		        .put()
 		        .uri("/201")
 		        .responseContent()
-		        .blockLast();
+		        .blockLast(Duration.ofSeconds(5));
 
 		createHttpClientForContextWithAddress()
 		        .doOnRequest((r, c) -> onReq.getAndIncrement())
@@ -752,7 +753,7 @@ class HttpClientTest extends BaseHttpTest {
 		        }))
 		        .responseContent()
 		        .repeat(4)
-		        .blockLast();
+		        .blockLast(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -772,7 +773,7 @@ class HttpClientTest extends BaseHttpTest {
 		        .uri("/201")
 		        .responseContent()
 		        .repeat(4)
-		        .blockLast();
+		        .blockLast(Duration.ofSeconds(30));
 	}
 
 	@Test
@@ -799,7 +800,7 @@ class HttpClientTest extends BaseHttpTest {
 		        .get()
 		        .uri("/201")
 		        .responseContent()
-		        .blockLast();
+		        .blockLast(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -831,7 +832,7 @@ class HttpClientTest extends BaseHttpTest {
 				                      .log()))
 				    .expectNextSequence(expected)
 				    .expectComplete()
-				    .verify();
+				    .verify(Duration.ofSeconds(5));
 
 		pr.dispose();
 	}
@@ -1148,7 +1149,8 @@ class HttpClientTest extends BaseHttpTest {
 				      .asString();
 
 		StepVerifier.create(content)
-		            .verifyError(PrematureCloseException.class);
+		            .expectError(PrematureCloseException.class)
+		            .verify(Duration.ofSeconds(5));
 
 		assertThat(requestError1.get()).isEqualTo("success");
 		assertThat(responseError1.get()).isNull();
@@ -1171,7 +1173,8 @@ class HttpClientTest extends BaseHttpTest {
 				        .asString();
 
 		StepVerifier.create(content)
-		            .verifyError(PrematureCloseException.class);
+		            .expectError(PrematureCloseException.class)
+		            .verify(Duration.ofSeconds(5));
 
 		assertThat(requestError2.get()).isNull();
 		assertThat(responseError2.get()).isEqualTo("success");
@@ -1202,7 +1205,8 @@ class HttpClientTest extends BaseHttpTest {
 
 		StepVerifier.create(content)
 		            .expectNext("success")
-		            .verifyComplete();
+		            .expectComplete()
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	@ParameterizedTest
@@ -3267,7 +3271,7 @@ class HttpClientTest extends BaseHttpTest {
 		}
 		finally {
 			loop.disposeLater()
-			    .block();
+			    .block(Duration.ofSeconds(5));
 		}
 	}
 

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpClientWithTomcatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,7 +182,7 @@ class HttpClientWithTomcatTest {
 		                    .uri("/status/404")
 		                    .responseSingle((r, buf) -> Mono.just(r.status().code()))
 		                    .log()
-		                    .block();
+		                    .block(Duration.ofSeconds(5));
 
 		assertThat(res).isNotNull();
 		if (res != 404) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -393,7 +393,7 @@ class HttpRedirectTest extends BaseHttpTest {
 		          .get()
 		          .uri("/")
 		          .responseContent()
-		          .blockLast();
+		          .blockLast(Duration.ofSeconds(5));
 
 		assertThat(followRedirects.get()).isEqualTo(4);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/HttpRedirectTest.java
@@ -783,6 +783,6 @@ class HttpRedirectTest extends BaseHttpTest {
 		        .as(StepVerifier::create)
 		        .expectNextMatches(tuple -> "OK".equals(tuple.getT1()) && tuple.getT2() == 200)
 		        .expectComplete()
-		        .verify(Duration.ofSeconds(5));
+		        .verify(Duration.ofSeconds(10));
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketClientOperationsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketClientOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ class WebsocketClientOperationsTest extends BaseHttpTest {
 
 		StepVerifier.create(response)
 		            .expectError(WebSocketHandshakeException.class)
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	private Mono<String> login(int port) {

--- a/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/client/WebsocketTest.java
@@ -126,7 +126,7 @@ class WebsocketTest extends BaseHttpTest {
 				          .handle((i, o) -> i.receive().asString())
 				          .log("client")
 				          .collectList()
-				          .block();
+				          .block(Duration.ofSeconds(5));
 
 		assertThat(res).isNotNull();
 		assertThat(res.get(0)).isEqualTo("test");
@@ -187,7 +187,7 @@ class WebsocketTest extends BaseHttpTest {
 		                      .log())
 		            .expectNextSequence(expected)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -240,7 +240,7 @@ class WebsocketTest extends BaseHttpTest {
 		StepVerifier.create(response)
 		            .expectNextMatches(list -> "1000 World!".equals(list.get(999)))
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 
 		log.debug("FINISHED: server[" + serverRes.get() + "] / client[" + clientRes + "]");
 	}
@@ -274,7 +274,7 @@ class WebsocketTest extends BaseHttpTest {
 		                      .log())
 		            .expectNextSequence(expected)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -587,7 +587,7 @@ class WebsocketTest extends BaseHttpTest {
 				                      .log()))
 		            .expectNextSequence(expected)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 
 		pr.dispose();
 	}
@@ -953,7 +953,7 @@ class WebsocketTest extends BaseHttpTest {
 				          .get()
 				          .uri("/ws")
 				          .response()
-				          .block();
+				          .block(Duration.ofSeconds(5));
 		assertThat(res).isNotNull();
 		assertThat(res.status()).isEqualTo(HttpResponseStatus.SWITCHING_PROTOCOLS);
 	}
@@ -986,7 +986,7 @@ class WebsocketTest extends BaseHttpTest {
 				          .uri("/ws")
 				          .receive()
 				          .asString()
-				          .blockLast();
+				          .blockLast(Duration.ofSeconds(5));
 
 		assertThat(res).isNotNull()
 		               .isEqualTo("test");

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpSendFileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -346,7 +346,7 @@ class HttpSendFileTests extends BaseHttpTest {
 				    .aggregate()
 				    .asByteArray()
 				    .onErrorReturn(IOException.class, expectedContent == null ? new byte[0] :  expectedContent)
-				    .block();
+				    .block(Duration.ofSeconds(5));
 
 		assertThat(response).isEqualTo(expectedContent == null ? Files.readAllBytes(tempFile) : expectedContent);
 	}

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -322,7 +322,7 @@ class HttpServerTests extends BaseHttpTest {
 		                              .send(src)
 		                              .responseSingle((res, buf) -> Mono.just(res.status().code())))
 		    .collectList()
-		    .block();
+		    .block(Duration.ofSeconds(5));
 	}
 
 	//from https://github.com/reactor/reactor-netty/issues/90
@@ -354,7 +354,7 @@ class HttpServerTests extends BaseHttpTest {
 			                 .responseContent()
 			                 .aggregate()
 			                 .asString()
-			                 .block();
+			                 .block(Duration.ofSeconds(5));
 
 			// checking the response status, OK
 			assertThat(response).isEqualTo("200");
@@ -376,7 +376,7 @@ class HttpServerTests extends BaseHttpTest {
 			                 .responseContent()
 			                 .aggregate()
 			                 .asString()
-			                 .block();
+			                 .block(Duration.ofSeconds(5));
 
 			assertThat(response).isEqualTo("201");
 		}
@@ -399,7 +399,7 @@ class HttpServerTests extends BaseHttpTest {
 				          .get()
 				          .uri("/return")
 				          .responseSingle((res, buf) -> Mono.just(res.status().code()))
-				          .block();
+				          .block(Duration.ofSeconds(5));
 		assertThat(code).isEqualTo(500);
 	}
 
@@ -592,14 +592,14 @@ class HttpServerTests extends BaseHttpTest {
 				          .get()
 				          .uri("/hello")
 				          .responseSingle((res, buf) -> Mono.just(res.status().code()))
-				          .block();
+				          .block(Duration.ofSeconds(5));
 		assertThat(code).isEqualTo(200);
 
 		code = createClient(disposableServer.port())
 		                 .get()
 		                 .uri("/helloMan")
 		                 .responseSingle((res, buf) -> Mono.just(res.status().code()))
-		                 .block();
+		                 .block(Duration.ofSeconds(5));
 		assertThat(code).isEqualTo(404);
 	}
 
@@ -943,7 +943,7 @@ class HttpServerTests extends BaseHttpTest {
 		StepVerifier.create(status)
 		            .expectNextMatches(HttpResponseStatus.REQUEST_URI_TOO_LONG::equals)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -965,7 +965,7 @@ class HttpServerTests extends BaseHttpTest {
 		StepVerifier.create(status)
 		            .expectNextMatches(HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE::equals)
 		            .expectComplete()
-		            .verify();
+		            .verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -1003,7 +1003,7 @@ class HttpServerTests extends BaseHttpTest {
 		          .responseContent()
 		          .aggregate()
 		          .asString()
-		          .block();
+		          .block(Duration.ofSeconds(5));
 
 		assertThat(channelRef.get()).isNotNull();
 		assertThat(chunkSize).as("line length").hasValue(789);
@@ -1265,7 +1265,8 @@ class HttpServerTests extends BaseHttpTest {
 				          .get()
 				          .uri("/")
 				          .responseContent())
-				    .verifyError(PrematureCloseException.class);
+				    .expectError(PrematureCloseException.class)
+				    .verify(Duration.ofSeconds(5));
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(error.get()).isInstanceOf(AbortedException.class);
@@ -1315,7 +1316,7 @@ class HttpServerTests extends BaseHttpTest {
 			                   .doFinally(sig -> latch.countDown())
 			                   .then(Mono.delay(Duration.ofMillis(500)));
 		          })
-		          .blockLast();
+		          .blockLast(Duration.ofSeconds(5));
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(receiver.get()).containsAll(test);
@@ -1354,7 +1355,7 @@ class HttpServerTests extends BaseHttpTest {
 		                                              statusClient.set(o);
 		                                              latch.countDown();
 		                                          })))
-		          .blockLast();
+		          .blockLast(Duration.ofSeconds(5));
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(statusClient.get()).isNotNull()
@@ -2830,7 +2831,8 @@ class HttpServerTests extends BaseHttpTest {
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/yes/value")
 				.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 				.expectNext("/yes/{value}")
-				.verifyComplete();
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -2844,7 +2846,8 @@ class HttpServerTests extends BaseHttpTest {
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/yes/value")
 				.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 				.expectNext("/yes/value")
-				.verifyComplete();
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -2859,7 +2862,8 @@ class HttpServerTests extends BaseHttpTest {
 			StepVerifier.create(createClient(disposableServer.port()).get().uri("/yes/value")
 					.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 					.expectNext("/yes/value")
-					.verifyComplete();
+					.expectComplete()
+					.verify(Duration.ofSeconds(5));
 		}
 		finally {
 			if (disposableServer != null) {
@@ -2873,7 +2877,8 @@ class HttpServerTests extends BaseHttpTest {
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/yes/value")
 				.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 				.expectNext("/yes/{value}")
-				.verifyComplete();
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -2888,7 +2893,8 @@ class HttpServerTests extends BaseHttpTest {
 			StepVerifier.create(createClient(disposableServer.port()).get().uri("/yes/value")
 					.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 					.expectNext("/yes/value")
-					.verifyComplete();
+					.expectComplete()
+					.verify(Duration.ofSeconds(5));
 		}
 		finally {
 			if (disposableServer != null) {
@@ -2902,7 +2908,8 @@ class HttpServerTests extends BaseHttpTest {
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/yes/value")
 				.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 				.expectNext("/yes/{value}")
-				.verifyComplete();
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
 	}
 
 	private static final Comparator<HttpRouteHandlerMetadata> comparator = (o1, o2) -> {
@@ -2965,12 +2972,14 @@ class HttpServerTests extends BaseHttpTest {
 			StepVerifier.create(createClient(disposableServer.port()).get().uri("/route1")
 					.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 					.expectNext("/route1")
-					.verifyComplete();
+					.expectComplete()
+					.verify(Duration.ofSeconds(5));
 
 			StepVerifier.create(createClient(disposableServer.port()).get().uri("/route2")
 					.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 					.expectNext("/route2")
-					.verifyComplete();
+					.expectComplete()
+					.verify(Duration.ofSeconds(5));
 		}
 		finally {
 			if (disposableServer != null) {
@@ -2987,12 +2996,14 @@ class HttpServerTests extends BaseHttpTest {
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/route1")
 				.response())
 				.expectNextMatches(response -> response.status().equals(HttpResponseStatus.NOT_FOUND))
-				.verifyComplete();
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
 
 		StepVerifier.create(createClient(disposableServer.port()).get().uri("/route2")
 				.responseSingle((response, byteBufMono) -> byteBufMono.asString()))
 				.expectNext("/route2")
-				.verifyComplete();
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
 	}
 
 	@ParameterizedTest(name = "{displayName}({arguments})")

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -111,6 +111,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Publisher;
@@ -1048,7 +1049,8 @@ class HttpServerTests extends BaseHttpTest {
 				(req, out) -> {
 					req.addHeader("Connection", "close");
 					return out;
-				});
+				},
+				HttpProtocol.HTTP11);
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(ReferenceCountUtil.refCnt(data)).isEqualTo(0);
 	}
@@ -1063,12 +1065,14 @@ class HttpServerTests extends BaseHttpTest {
 				(req, out) -> {
 					req.addHeader("Connection", "close");
 					return out;
-				});
+				},
+				HttpProtocol.HTTP11);
 		assertThat(ReferenceCountUtil.refCnt(data)).isEqualTo(0);
 	}
 
-	@Test
-	void testDropPublisher_1() throws Exception {
+	@ParameterizedTest
+	@EnumSource(value = HttpProtocol.class, names = {"HTTP11", "H2C"})
+	void testDropPublisher_1(HttpProtocol protocol) throws Exception {
 		CountDownLatch latch = new CountDownLatch(1);
 		ByteBuf data = ByteBufAllocator.DEFAULT.buffer();
 		data.writeCharSequence("test", Charset.defaultCharset());
@@ -1077,7 +1081,8 @@ class HttpServerTests extends BaseHttpTest {
 				                 .send(Flux.defer(() -> Flux.just(data, data.retain(), data.retain()))
 				                           .doFinally(s -> latch.countDown()))
 				                 .then(),
-				(req, out) -> out);
+				(req, out) -> out,
+				protocol);
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(ReferenceCountUtil.refCnt(data)).isEqualTo(0);
 	}
@@ -1090,7 +1095,8 @@ class HttpServerTests extends BaseHttpTest {
 				(req, res) -> res.header("Content-Length", "0")
 				                 .send(Mono.just(data))
 				                 .then(),
-				(req, out) -> out);
+				(req, out) -> out,
+				HttpProtocol.HTTP11);
 		assertThat(ReferenceCountUtil.refCnt(data)).isEqualTo(0);
 	}
 
@@ -1101,23 +1107,27 @@ class HttpServerTests extends BaseHttpTest {
 		doTestDropData(
 				(req, res) -> res.header("Content-Length", "0")
 				                 .sendObject(data),
-				(req, out) -> out);
+				(req, out) -> out,
+				HttpProtocol.HTTP11);
 		assertThat(ReferenceCountUtil.refCnt(data)).isEqualTo(0);
 	}
 
 	private void doTestDropData(
 			BiFunction<? super HttpServerRequest, ? super
 					HttpServerResponse, ? extends Publisher<Void>> serverFn,
-			BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>> clientFn)
+			BiFunction<? super HttpClientRequest, ? super NettyOutbound, ? extends Publisher<Void>> clientFn,
+			HttpProtocol protocol)
 			throws Exception {
 		disposableServer =
 				createServer()
+				          .protocol(protocol)
 				          .handle(serverFn)
 				          .bindNow(Duration.ofSeconds(30));
 
 		CountDownLatch latch = new CountDownLatch(1);
 		String response =
 				createClient(disposableServer.port())
+				          .protocol(protocol)
 				          .doOnRequest((req, conn) -> conn.onTerminate()
 				                                          .subscribe(null, null, latch::countDown))
 				          .request(HttpMethod.GET)

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -1266,7 +1266,7 @@ class HttpServerTests extends BaseHttpTest {
 				          .uri("/")
 				          .responseContent())
 				    .expectError(PrematureCloseException.class)
-				    .verify(Duration.ofSeconds(5));
+				    .verify(Duration.ofSeconds(10));
 
 		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(error.get()).isInstanceOf(AbortedException.class);

--- a/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/server/HttpServerTests.java
@@ -2285,7 +2285,7 @@ class HttpServerTests extends BaseHttpTest {
 		        .aggregate()
 		        .as(StepVerifier::create)
 		        .expectError()
-		        .verify(Duration.ofSeconds(5));
+		        .verify(Duration.ofSeconds(10));
 
 		StepVerifier.create(error.asMono())
 		            .expectNextMatches(t -> t instanceof SslHandshakeTimeoutException)

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/DefaultPooledConnectionProviderTest.java
@@ -670,12 +670,23 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 		}
 
 		MeterRegistrarImpl meterRegistrar;
-		String metricsName = "";
+		CountDownLatch meterRemoved = new CountDownLatch(2);
+		String pendingTime = isHttp2 ? ".pending.streams.time" : ".pending.connections.time";
+		String metricsName1 = CONNECTION_PROVIDER_PREFIX + ACTIVE_CONNECTIONS;
+		String metricsName2 = CONNECTION_PROVIDER_PREFIX + pendingTime;
+		String metricsTagName = "";
 		if (isBuiltInMetrics) {
 			meterRegistrar = null;
 			builder.metrics(true);
 
-			metricsName = isHttp2 ? "http2.testDisposeInactivePoolsInBackground" : "testDisposeInactivePoolsInBackground";
+			metricsTagName = isHttp2 ? "http2.testDisposeInactivePoolsInBackground" : "testDisposeInactivePoolsInBackground";
+
+			registry.config().onMeterRemoved(meter -> {
+				if (metricsName1.equals(meter.getId().getName()) ||
+						metricsName2.equals(meter.getId().getName())) {
+					meterRemoved.countDown();
+				}
+			});
 		}
 		else {
 			meterRegistrar = new MeterRegistrarImpl();
@@ -711,18 +722,15 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 
 			InetSocketAddress sa = (InetSocketAddress) serverAddress.get();
 			String address = sa.getHostString() + ":" + sa.getPort();
-			String pendingTime = isHttp2 ? ".pending.streams.time" : ".pending.connections.time";
 
 			assertThat(provider.channelPools.size()).isEqualTo(1);
 			if (meterRegistrar != null) {
 				assertThat(meterRegistrar.registered.get()).isTrue();
 			}
 			else {
-				assertGauge(registry, CONNECTION_PROVIDER_PREFIX + ACTIVE_CONNECTIONS,
-						REMOTE_ADDRESS, address, NAME, metricsName).isNotNull();
+				assertGauge(registry, metricsName1, REMOTE_ADDRESS, address, NAME, metricsTagName).isNotNull();
 
-				assertTimer(registry, CONNECTION_PROVIDER_PREFIX + pendingTime,
-						REMOTE_ADDRESS, address, NAME, metricsName).isNotNull();
+				assertTimer(registry, metricsName2, REMOTE_ADDRESS, address, NAME, metricsTagName).isNotNull();
 			}
 
 			if (enableEvictInBackground) {
@@ -737,22 +745,23 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 
 			assertThat(provider.isDisposed()).isEqualTo(enableEvictInBackground);
 			if (meterRegistrar != null) {
+				if (enableEvictInBackground) {
+					assertThat(meterRegistrar.latch.await(30, TimeUnit.SECONDS)).isTrue();
+				}
 				assertThat(meterRegistrar.deRegistered.get()).isEqualTo(enableEvictInBackground);
 			}
 			else {
 				if (enableEvictInBackground) {
-					assertGauge(registry, CONNECTION_PROVIDER_PREFIX + ACTIVE_CONNECTIONS,
-							REMOTE_ADDRESS, address, NAME, metricsName).isNull();
+					assertThat(meterRemoved.await(30, TimeUnit.SECONDS)).isTrue();
 
-					assertTimer(registry, CONNECTION_PROVIDER_PREFIX + pendingTime,
-							REMOTE_ADDRESS, address, NAME, metricsName).isNull();
+					assertGauge(registry, metricsName1, REMOTE_ADDRESS, address, NAME, metricsTagName).isNull();
+
+					assertTimer(registry, metricsName2, REMOTE_ADDRESS, address, NAME, metricsTagName).isNull();
 				}
 				else {
-					assertGauge(registry, CONNECTION_PROVIDER_PREFIX + ACTIVE_CONNECTIONS,
-							REMOTE_ADDRESS, address, NAME, metricsName).isNotNull();
+					assertGauge(registry, metricsName1, REMOTE_ADDRESS, address, NAME, metricsTagName).isNotNull();
 
-					assertTimer(registry, CONNECTION_PROVIDER_PREFIX + pendingTime,
-							REMOTE_ADDRESS, address, NAME, metricsName).isNotNull();
+					assertTimer(registry, metricsName2, REMOTE_ADDRESS, address, NAME, metricsTagName).isNotNull();
 				}
 			}
 		}
@@ -888,6 +897,7 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 	static final class MeterRegistrarImpl implements ConnectionProvider.MeterRegistrar {
 		AtomicBoolean registered = new AtomicBoolean();
 		AtomicBoolean deRegistered = new AtomicBoolean();
+		final CountDownLatch latch = new CountDownLatch(1);
 
 		MeterRegistrarImpl() {
 		}
@@ -900,6 +910,7 @@ class DefaultPooledConnectionProviderTest extends BaseHttpTest {
 		@Override
 		public void deRegisterMetrics(String poolName, String id, SocketAddress remoteAddress) {
 			deRegistered.compareAndSet(false, true);
+			latch.countDown();
 		}
 	}
 }

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.BaseHttpTest;
@@ -230,8 +232,9 @@ class PooledConnectionProviderDefaultMetricsTest extends BaseHttpTest {
 		assertGauge(registry, CONNECTION_PROVIDER_PREFIX + MAX_PENDING_CONNECTIONS, NAME, poolName).hasValueEqualTo(expectedMaxPendingAcquire);
 	}
 
-	@Test
-	void testConnectionPoolPendingAcquireSize() throws Exception {
+	@ParameterizedTest
+	@ValueSource(longs = {0, 50, 500})
+	void testConnectionPoolPendingAcquireSize(long disposeTimeoutMillis) throws Exception {
 		Http2SslContextSpec serverCtx = Http2SslContextSpec.forServer(ssc.certificate(), ssc.privateKey());
 		Http2SslContextSpec clientCtx =
 				Http2SslContextSpec.forClient()
@@ -248,13 +251,21 @@ class PooledConnectionProviderDefaultMetricsTest extends BaseHttpTest {
 										.delayElements(Duration.ofMillis(4))))
 						.bindNow();
 
-		ConnectionProvider provider = ConnectionProvider
+		ConnectionProvider.Builder builder = ConnectionProvider
 				.builder("testConnectionPoolPendingAcquireSize")
 				.pendingAcquireMaxCount(1000)
 				.maxConnections(500)
-				.metrics(true)
-				.build();
+				.metrics(true);
+		ConnectionProvider provider = disposeTimeoutMillis == 0 ? builder.build() :
+				builder.disposeTimeout(Duration.ofMillis(disposeTimeoutMillis)).build();
 
+		CountDownLatch meterRemoved = new CountDownLatch(1);
+		String name = CONNECTION_PROVIDER_PREFIX + PENDING_STREAMS;
+		registry.config().onMeterRemoved(meter -> {
+			if (name.equals(meter.getId().getName())) {
+				meterRemoved.countDown();
+			}
+		});
 		try {
 			CountDownLatch latch = new CountDownLatch(1);
 			AtomicInteger counter = new AtomicInteger();
@@ -294,14 +305,17 @@ class PooledConnectionProviderDefaultMetricsTest extends BaseHttpTest {
 
 			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 
-			assertGauge(registry, CONNECTION_PROVIDER_PREFIX + PENDING_STREAMS, NAME, "http2.testConnectionPoolPendingAcquireSize").hasValueEqualTo(0);
+			assertGauge(registry, name, NAME, "http2.testConnectionPoolPendingAcquireSize").hasValueEqualTo(0);
 		}
 		finally {
 			provider.disposeLater()
 					.block(Duration.ofSeconds(30));
 		}
+
+		assertThat(meterRemoved.await(30, TimeUnit.SECONDS)).isTrue();
+
 		// deRegistered
-		assertGauge(registry, CONNECTION_PROVIDER_PREFIX + PENDING_STREAMS, NAME, "http2.testConnectionPoolPendingAcquireSize").isNull();
+		assertGauge(registry, name, NAME, "http2.testConnectionPoolPendingAcquireSize").isNull();
 	}
 
 	@Test

--- a/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/resources/PooledConnectionProviderDefaultMetricsTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static reactor.netty.Metrics.ACTIVE_CONNECTIONS;
 import static reactor.netty.Metrics.ACTIVE_STREAMS;
 import static reactor.netty.Metrics.ERROR;
@@ -304,6 +305,11 @@ class PooledConnectionProviderDefaultMetricsTest extends BaseHttpTest {
 					.blockLast(Duration.ofSeconds(30));
 
 			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+
+			await().atMost(1000, TimeUnit.MILLISECONDS)
+			       .with()
+			       .pollInterval(50, TimeUnit.MILLISECONDS)
+			       .untilAsserted(() -> assertGauge(registry, name, NAME, "http2.testConnectionPoolPendingAcquireSize").hasValueEqualTo(0));
 
 			assertGauge(registry, name, NAME, "http2.testConnectionPoolPendingAcquireSize").hasValueEqualTo(0);
 		}

--- a/reactor-netty-incubator-quic/README.md
+++ b/reactor-netty-incubator-quic/README.md
@@ -13,8 +13,8 @@ With `Gradle` from [repo.spring.io](https://repo.spring.io) or `Maven Central` r
     }
 
     dependencies {
-      //compile "io.projectreactor.netty.incubator:reactor-netty-incubator-quic:0.1.19-SNAPSHOT"
-      compile "io.projectreactor.netty.incubator:reactor-netty-incubator-quic:0.1.18"
+      //compile "io.projectreactor.netty.incubator:reactor-netty-incubator-quic:0.1.20-SNAPSHOT"
+      compile "io.projectreactor.netty.incubator:reactor-netty-incubator-quic:0.1.19"
     }
 ```
 

--- a/reactor-netty-incubator-quic/src/test/java/reactor/netty/incubator/quic/QuicServerTests.java
+++ b/reactor-netty-incubator-quic/src/test/java/reactor/netty/incubator/quic/QuicServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2024 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -337,7 +337,7 @@ class QuicServerTests extends BaseQuicTests {
 		                                                latch.countDown();
 		                                            })
 		                                            .then()))
-		      .block();
+		      .block(Duration.ofSeconds(5));
 
 		assertThat(latch.await(5, TimeUnit.SECONDS)).as("latch wait").isTrue();
 


### PR DESCRIPTION
pr_rerun pending-acquire-timer to 1.1.x