### PR TITLE
Add info for `HTTP/2` connection pool metrics

### DIFF
--- a/docs/asciidoc/http-client-conn-provider.adoc
+++ b/docs/asciidoc/http-client-conn-provider.adoc
@@ -89,6 +89,17 @@ It exposes all metrics with a prefix of `reactor.netty.connection.provider`.
 
 include::conn-provider-metrics.adoc[]
 
+The following table provides information for the HTTP client metrics when it is configured to serve `HTTP/2` traffic:
+
+[width="100%",options="header"]
+|=======
+| metric name | type | description
+| reactor.netty.connection.provider.active.streams | Gauge | The number of the active HTTP/2 streams.
+See <<observability-metrics-active-streams>>
+| reactor.netty.connection.provider.pending.streams | Gauge | The number of requests that are waiting for opening HTTP/2 stream.
+See <<observability-metrics-pending-streams>>
+|=======
+
 The following example enables that integration:
 
 ====


### PR DESCRIPTION
pr_rerun refdoc-http2-pool-metrics to main