### PR TITLE
Bump `actions/checkout` to version `4.1.3`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,7 @@ jobs:
   build-branch-doc:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
       - name: Set up Ruby for asciidoctor-pdf
         uses: ruby/setup-ruby@6bd3d993c602f6b675728ebaecb2b569ff86e99b # v1
         with:


### PR DESCRIPTION
pr_rerun dependabot/github_actions/main/actions/checkout-4.1.3 to main