### PR TITLE
Remove unnecessary `:toc:` from `appendices.adoc`

### DIFF
--- a/docs/modules/ROOT/pages/appendices.adoc
+++ b/docs/modules/ROOT/pages/appendices.adoc
@@ -1,6 +1,5 @@
 = Appendices
 :sectnums:
-:toc:
 
 [appendix]
 include::faq.adoc[leveloffset=1]

--- a/docs/modules/ROOT/pages/appendices.adoc
+++ b/docs/modules/ROOT/pages/appendices.adoc
@@ -1,5 +1,4 @@
 = Appendices
-:sectnums:
 
 [appendix]
 include::faq.adoc[leveloffset=1]


### PR DESCRIPTION
pr_rerun remove-toc-adoc to main