### PR TITLE
Remove unnecessary `:toc:` from `appendices.adoc`

### DIFF
--- a/docs/asciidoc/tcp-client.adoc
+++ b/docs/asciidoc/tcp-client.adoc
@@ -181,7 +181,7 @@ By default, the `TCP` client is configured with the following options:
 [source,java,indent=0]
 .{sourcedir}/reactor/netty/tcp/TcpClientConnect.java
 ----
-include::{sourcedir}/reactor/netty/tcp/TcpClientConnect.java[lines=36..41]
+include::{sourcedir}/reactor/netty/tcp/TcpClientConnect.java[lines=35..40]
 ----
 ====
 

--- a/docs/modules/ROOT/pages/appendices.adoc
+++ b/docs/modules/ROOT/pages/appendices.adoc
@@ -1,6 +1,5 @@
 = Appendices
 :sectnums:
-:toc:
 
 [appendix]
 include::faq.adoc[leveloffset=1]

--- a/docs/modules/ROOT/pages/appendices.adoc
+++ b/docs/modules/ROOT/pages/appendices.adoc
@@ -1,5 +1,4 @@
 = Appendices
-:sectnums:
 
 [appendix]
 include::faq.adoc[leveloffset=1]


### PR DESCRIPTION
pr_rerun remove-toc-adoc to main