### PR TITLE
`GraalVM` smoke tests: Ensure the needed dependencies are built upfront

### DIFF
--- a/.github/workflows/check_graalvm.yml
+++ b/.github/workflows/check_graalvm.yml
@@ -12,6 +12,10 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-11]
         transport: [native, nio]
+        exclude:
+          # macOS - https://github.com/netty/netty/issues/9689
+          - os: macos-11
+            transport: native
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check_graalvm.yml
+++ b/.github/workflows/check_graalvm.yml
@@ -15,11 +15,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '8'
+          path: reactor-netty
+      - uses: actions/checkout@v4
+        with:
+          repository: netty-contrib/socks-proxy
+          path: socks-proxy
+      - uses: actions/checkout@v4
+        with:
+          repository: netty-contrib/codec-multipart
+          path: codec-multipart
       - name: Download GraalVM 17
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
@@ -32,8 +37,15 @@ jobs:
       - name: Set up GraalVM 17
         uses: actions/setup-java@v3
         with:
-            distribution: 'jdkfile'
-            jdkFile: ${{ runner.temp }}/java_package.tar.gz
-            java-version: '17'
+          distribution: 'jdkfile'
+          jdkFile: ${{ runner.temp }}/java_package.tar.gz
+          java-version: '17'
+      - name: Build socks-proxy
+        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha6-SNAPSHOT"
+        working-directory: ./socks-proxy
+      - name: Build codec-multipart
+        run: ./mvnw install -DskipTests=true "-Dnetty.version=5.0.0.Alpha6-SNAPSHOT"
+        working-directory: ./codec-multipart
       - name: Build with Gradle
         run: ./gradlew :reactor-netty5-graalvm-smoke-tests:nativeTest --no-daemon -PforceTransport=${{ matrix.transport }}
+        working-directory: ./reactor-netty


### PR DESCRIPTION
pr_rerun netty5-ci-graalvm to netty5